### PR TITLE
Metrics now wrapped in a Guard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@ To ensure a quality PR experience this call may be recorded. Just Kidding, but w
 1. The Name of the PR will show up in the changelog so make it a good one, we will rename PRs or reject based on the name.
 2. Please make the PR as small as possible to achieve the bugfix or feature. Big prs often are scary and hard to review.
 3. Be kind to your reviewers 🤓
-   4. Add a good description, so we can see what the PR is all about without investing the time in the code review. We will often review code at a certain time in the day and having a list if important prs to review helps us move that along.
+4. Add a good description, so we can see what the PR is all about without investing the time in the code review. We will often review code at a certain time in the day and having a list if important prs to review helps us move that along.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,4 +5,4 @@ To ensure a quality PR experience this call may be recorded. Just Kidding, but w
 1. The Name of the PR will show up in the changelog so make it a good one, we will rename PRs or reject based on the name.
 2. Please make the PR as small as possible to achieve the bugfix or feature. Big prs often are scary and hard to review.
 3. Be kind to your reviewers 🤓
-4. Add a good description, so we can see what the PR is all about without investing the time in the code review. We will often review code at a certain time in the day and having a list if important prs to review helps us move that along.
+   4. Add a good description, so we can see what the PR is all about without investing the time in the code review. We will often review code at a certain time in the day and having a list if important prs to review helps us move that along.

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test-ledger
 *.swp
 *error.log
 *iml
+programs

--- a/README.md
+++ b/README.md
@@ -81,8 +81,16 @@ This repo contains a docker File that allows you to run an test the plerkle plug
 To test it you can build the container with```docker compose build .``` and run it with ```docker compose up```. 
 
 You will want to change the programs you are listening to in `./docker/runs.sh`. Once you spin up the validator send your transactions to the docker host as you would a normal RPC.
-If you want to add a custom program you will need to change `docker-compose.yml` to mount in a volume with your .so file of your built program and change `./docker/runs.sh` where you see the line that has
+
+Any program .so files you add to the /so/ file upon running the docker compose system will be added to the local validator.
+
+You need to name the so file what you want the public key to be:
 ```bash
- --bpf-program metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s /so/mpl_token_metadata.so
+metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s.so
+```
+This is because of this line in the ``docker-compose.yml`` file. 
+```yaml
+      - ./programs:/so/:ro
 ```
 
+You can comment this out if you dont want it.

--- a/Solana.Dockerfile
+++ b/Solana.Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/solana:v1.10.34 as builder
+FROM solanalabs/solana:v1.11.3 as builder
 RUN apt-get update \
       && apt-get -y install \
            wget \
@@ -9,22 +9,21 @@ RUN apt-get update \
            libelf-dev \
            linux-headers-generic \
            pkg-config \
-           curl
+           curl \
+          cmake \
+          protobuf-compiler
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /rust/
-COPY deps /rust/deps
-COPY lib /rust/lib
 COPY plerkle_serialization /rust/plerkle_serialization
-COPY messenger /rust/messenger
+COPY plerkle_messenger /rust/plerkle_messenger
 COPY plerkle /rust/plerkle
 WORKDIR /rust/plerkle
 RUN cargo build
 
-FROM solanalabs/solana:v1.10.34
+FROM solanalabs/solana:v1.11.3
 COPY --from=builder /rust/plerkle/target/debug/libplerkle.so /plugin/plugin.so
-COPY --from=builder /so/ /so/
-
 COPY ./docker .
 RUN chmod +x ./*.sh
 ENTRYPOINT [ "./runs.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       dockerfile: Solana.Dockerfile
     volumes:
       - ./ledger:/config:rw
+      - ./programs:/so/:ro
     environment:
       RUST_LOG: warn
       PLUGIN_CONFIG_RELOAD_TTL: 300

--- a/docker/runs.sh
+++ b/docker/runs.sh
@@ -37,6 +37,12 @@ cat << EOL > accountsdb-plugin-config.json
     }
 }
 EOL
+
+programs=()
+for prog in /so/*; do
+    programs+=("--bpf-program" "$(basename $prog .so)" "$prog")
+done
+
 export RUST_BACKTRACE=1
 dataDir=$PWD/config/"$(basename "$0" .sh)"
 ledgerDir=$PWD/config/ledger
@@ -49,16 +55,9 @@ args=(
   --log
   --reset
   --rpc-port 8899
-#  --bpf-program metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s /so/mpl_token_metadata.so
-#  --bpf-program BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY /so/bubblegum.so
-#  --bpf-program GRoLLMza82AiYN7W9S9KCCtCyyPRAQP2ifBy4v4D5RMD /so/gummyroll.so
-#  --bpf-program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA /so/spl_token.so
-#  --bpf-program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb /so/spl_token_2022.so
-#  --bpf-program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL /so/spl_associated_token_account.so
-#  --bpf-program WRAPYChf58WFCnyjXKJHtrPgzKXgHp6MD9aVDqJBbGh /so/candy_wrapper.so
   --geyser-plugin-config accountsdb-plugin-config.json
 )
 # shellcheck disable=SC2086
 cat accountsdb-plugin-config.json
-echo "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS
-solana-test-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS
+ls -la /so/
+solana-test-validator  "${programs[@]}" "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS

--- a/plerkle/Cargo.toml
+++ b/plerkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle"
 description = "Geyser plugin with dynamic config reloading, message bus agnostic abstractions and a whole lot of fun."
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"
@@ -32,9 +32,9 @@ chrono = "0.4.19" # did anyone say leftpad ?
 solana-runtime = "1.11.3"
 tracing = "0.1.35"
 hex = "0.4.3"
-plerkle_messenger = { path="../plerkle_messenger", version = "0.0.1", features = ["redis"] }
+plerkle_messenger = { path="../plerkle_messenger", version = "0.0.2", features = ["redis"] }
 flatbuffers = "2.1.2"
-plerkle_serialization = { path="../plerkle_serialization", version = "0.0.1" }
+plerkle_serialization = { path="../plerkle_serialization", version = "0.0.2" }
 tokio = { version = "1.17.0", features = ["full"] }
 figment = { version = "0.10.6", features = ["env", "test"] }
 

--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -38,6 +38,7 @@ use {
         sync::mpsc::{self as mpsc, Sender},
     },
 };
+use crate::metrics::safe_metric;
 
 struct SerializedData<'a> {
     stream: &'static str,
@@ -284,7 +285,9 @@ impl GeyserPlugin for Plerkle<'static> {
                     };
                     let _ = sender.send(data).await;
                 });
-                statsd_count!("account_seen_event", 1, "owner" => &owner);
+                safe_metric(|| {
+                    statsd_count!("account_seen_event", 1, "owner" => &owner);
+                });
             }
             _ => {
                 error!("Old Transaction Replica Object")
@@ -297,7 +300,9 @@ impl GeyserPlugin for Plerkle<'static> {
     fn notify_end_of_startup(
         &mut self,
     ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-        statsd_time!("startup.timer", self.started_at.unwrap().elapsed());
+        safe_metric(|| {
+            statsd_time!("startup.timer", self.started_at.unwrap().elapsed());
+        });
         info!("END OF STARTUP");
         Ok(())
     }
@@ -369,7 +374,9 @@ impl GeyserPlugin for Plerkle<'static> {
                     };
                     let _ = sender.send(data).await;
                 });
-                statsd_count!("transaction_seen_event", 1, "slot-idx" => &slt_idx);
+                safe_metric(|| {
+                    statsd_count!("transaction_seen_event", 1, "slot-idx" => &slt_idx);
+                })
             }
             _ => {
                 error!("Old Transaction Replica Object")

--- a/plerkle/src/lib.rs
+++ b/plerkle/src/lib.rs
@@ -3,3 +3,5 @@ mod error;
 pub mod geyser_plugin_nft;
 pub mod serializer;
 pub mod transaction_selector;
+#[macro_use]
+mod metrics;

--- a/plerkle/src/metrics.rs
+++ b/plerkle/src/metrics.rs
@@ -1,0 +1,7 @@
+use cadence_macros::is_global_default_set;
+
+pub fn safe_metric<F: Fn() -> ()>(f: F) {
+    if is_global_default_set() {
+        f()
+    }
+}

--- a/plerkle_messenger/Cargo.toml
+++ b/plerkle_messenger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_messenger"
 description = "Metaplex Messenger trait for Geyser plugin producer/consumer patterns."
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"
@@ -9,7 +9,7 @@ edition = "2021"
 readme = "Readme.md"
 
 [dependencies]
-plerkle_serialization = { path = "../plerkle_serialization", version = "0.0.1" }
+plerkle_serialization = { path = "../plerkle_serialization", version = "0.0.2" }
 redis = { version = "0.21.5", features = ["aio", "tokio-comp", "streams"], optional = true }
 metaplex-pulsar = { version = "4.1.1", optional = true }
 log = "0.4.11"

--- a/plerkle_serialization/Cargo.toml
+++ b/plerkle_serialization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_serialization"
 description = "Metaplex Flatbuffers Plerkle Serialization for Geyser plugin producer/consumer patterns."
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"


### PR DESCRIPTION
Previously when running the Plerkle without a metrics configuration it was panicking. This wraps the metrics in a guard checking for the global metrics configuration to be present via the Cadence api.