### PR TITLE
Change Pubkey Table to Struct in Schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,7 +2213,7 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plerkle"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_messenger"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -2262,9 +2262,10 @@ dependencies = [
 
 [[package]]
 name = "plerkle_serialization"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "flatbuffers",
+ "solana-sdk",
 ]
 
 [[package]]

--- a/plerkle/Cargo.toml
+++ b/plerkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle"
 description = "Geyser plugin with dynamic config reloading, message bus agnostic abstractions and a whole lot of fun."
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"
@@ -32,9 +32,9 @@ chrono = "0.4.19" # did anyone say leftpad ?
 solana-runtime = "1.11.3"
 tracing = "0.1.35"
 hex = "0.4.3"
-plerkle_messenger = { path="../plerkle_messenger", version = "0.0.2", features = ["redis"] }
+plerkle_messenger = { path="../plerkle_messenger", version = "0.0.3", features = ["redis"] }
 flatbuffers = "2.1.2"
-plerkle_serialization = { path="../plerkle_serialization", version = "0.0.2" }
+plerkle_serialization = { path="../plerkle_serialization", version = "0.0.3" }
 tokio = { version = "1.17.0", features = ["full"] }
 figment = { version = "0.10.6", features = ["env", "test"] }
 

--- a/plerkle/src/serializer.rs
+++ b/plerkle/src/serializer.rs
@@ -87,11 +87,7 @@ pub fn serialize_transaction<'a>(
     let account_keys = if account_keys_len > 0 {
         let mut account_keys_fb_vec = Vec::with_capacity(account_keys_len);
         for key in account_keys.iter() {
-            let key = builder.create_vector(&key.to_bytes());
-            let pubkey = transaction_info::Pubkey::create(
-                &mut builder,
-                &transaction_info::PubkeyArgs { key: Some(key) },
-            );
+            let pubkey = transaction_info::Pubkey::new(&key.to_bytes());
             account_keys_fb_vec.push(pubkey);
         }
         Some(builder.create_vector(&account_keys_fb_vec))

--- a/plerkle_messenger/Cargo.toml
+++ b/plerkle_messenger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_messenger"
 description = "Metaplex Messenger trait for Geyser plugin producer/consumer patterns."
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"
@@ -9,7 +9,7 @@ edition = "2021"
 readme = "Readme.md"
 
 [dependencies]
-plerkle_serialization = { path = "../plerkle_serialization", version = "0.0.2" }
+plerkle_serialization = { path = "../plerkle_serialization", version = "0.0.3" }
 redis = { version = "0.21.5", features = ["aio", "tokio-comp", "streams"], optional = true }
 metaplex-pulsar = { version = "4.1.1", optional = true }
 log = "0.4.11"

--- a/plerkle_serialization/Cargo.toml
+++ b/plerkle_serialization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_serialization"
 description = "Metaplex Flatbuffers Plerkle Serialization for Geyser plugin producer/consumer patterns."
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"
@@ -11,6 +11,7 @@ readme = "Readme.md"
 
 [dependencies]
 flatbuffers = "2.1.2"
+solana-sdk = "1.10.38"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/plerkle_serialization/src/account_info_generated.rs
+++ b/plerkle_serialization/src/account_info_generated.rs
@@ -2,365 +2,309 @@
 
 
 
+use core::mem;
+use core::cmp::Ordering;
 
 extern crate flatbuffers;
-
+use self::flatbuffers::{EndianScalar, Follow};
 
 #[allow(unused_imports, dead_code)]
 pub mod account_info {
 
-    use core::cmp::Ordering;
-    use core::mem;
+  use core::mem;
+  use core::cmp::Ordering;
 
-    extern crate flatbuffers;
-    use self::flatbuffers::{EndianScalar, Follow};
+  extern crate flatbuffers;
+  use self::flatbuffers::{EndianScalar, Follow};
 
-    pub enum AccountInfoOffset {}
-    #[derive(Copy, Clone, PartialEq)]
+pub enum AccountInfoOffset {}
+#[derive(Copy, Clone, PartialEq)]
 
-    pub struct AccountInfo<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
+pub struct AccountInfo<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
 
-    impl<'a> flatbuffers::Follow<'a> for AccountInfo<'a> {
-        type Inner = AccountInfo<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
+impl<'a> flatbuffers::Follow<'a> for AccountInfo<'a> {
+  type Inner = AccountInfo<'a>;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table { buf, loc } }
+  }
+}
 
-    impl<'a> AccountInfo<'a> {
-        pub const VT_PUBKEY: flatbuffers::VOffsetT = 4;
-        pub const VT_LAMPORTS: flatbuffers::VOffsetT = 6;
-        pub const VT_OWNER: flatbuffers::VOffsetT = 8;
-        pub const VT_EXECUTABLE: flatbuffers::VOffsetT = 10;
-        pub const VT_RENT_EPOCH: flatbuffers::VOffsetT = 12;
-        pub const VT_DATA: flatbuffers::VOffsetT = 14;
-        pub const VT_WRITE_VERSION: flatbuffers::VOffsetT = 16;
-        pub const VT_SLOT: flatbuffers::VOffsetT = 18;
-        pub const VT_IS_STARTUP: flatbuffers::VOffsetT = 20;
+impl<'a> AccountInfo<'a> {
+  pub const VT_PUBKEY: flatbuffers::VOffsetT = 4;
+  pub const VT_LAMPORTS: flatbuffers::VOffsetT = 6;
+  pub const VT_OWNER: flatbuffers::VOffsetT = 8;
+  pub const VT_EXECUTABLE: flatbuffers::VOffsetT = 10;
+  pub const VT_RENT_EPOCH: flatbuffers::VOffsetT = 12;
+  pub const VT_DATA: flatbuffers::VOffsetT = 14;
+  pub const VT_WRITE_VERSION: flatbuffers::VOffsetT = 16;
+  pub const VT_SLOT: flatbuffers::VOffsetT = 18;
+  pub const VT_IS_STARTUP: flatbuffers::VOffsetT = 20;
 
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            AccountInfo { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args AccountInfoArgs<'args>,
-        ) -> flatbuffers::WIPOffset<AccountInfo<'bldr>> {
-            let mut builder = AccountInfoBuilder::new(_fbb);
-            builder.add_slot(args.slot);
-            builder.add_write_version(args.write_version);
-            builder.add_rent_epoch(args.rent_epoch);
-            builder.add_lamports(args.lamports);
-            if let Some(x) = args.data {
-                builder.add_data(x);
-            }
-            if let Some(x) = args.owner {
-                builder.add_owner(x);
-            }
-            if let Some(x) = args.pubkey {
-                builder.add_pubkey(x);
-            }
-            builder.add_is_startup(args.is_startup);
-            builder.add_executable(args.executable);
-            builder.finish()
-        }
+  #[inline]
+  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    AccountInfo { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+    args: &'args AccountInfoArgs<'args>
+  ) -> flatbuffers::WIPOffset<AccountInfo<'bldr>> {
+    let mut builder = AccountInfoBuilder::new(_fbb);
+    builder.add_slot(args.slot);
+    builder.add_write_version(args.write_version);
+    builder.add_rent_epoch(args.rent_epoch);
+    builder.add_lamports(args.lamports);
+    if let Some(x) = args.data { builder.add_data(x); }
+    if let Some(x) = args.owner { builder.add_owner(x); }
+    if let Some(x) = args.pubkey { builder.add_pubkey(x); }
+    builder.add_is_startup(args.is_startup);
+    builder.add_executable(args.executable);
+    builder.finish()
+  }
 
-        #[inline]
-        pub fn pubkey(&self) -> Option<&'a [u8]> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    AccountInfo::VT_PUBKEY,
-                    None,
-                )
-                .map(|v| v.safe_slice())
-        }
-        #[inline]
-        pub fn lamports(&self) -> u64 {
-            self._tab
-                .get::<u64>(AccountInfo::VT_LAMPORTS, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn owner(&self) -> Option<&'a [u8]> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    AccountInfo::VT_OWNER,
-                    None,
-                )
-                .map(|v| v.safe_slice())
-        }
-        #[inline]
-        pub fn executable(&self) -> bool {
-            self._tab
-                .get::<bool>(AccountInfo::VT_EXECUTABLE, Some(false))
-                .unwrap()
-        }
-        #[inline]
-        pub fn rent_epoch(&self) -> u64 {
-            self._tab
-                .get::<u64>(AccountInfo::VT_RENT_EPOCH, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn data(&self) -> Option<&'a [u8]> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    AccountInfo::VT_DATA,
-                    None,
-                )
-                .map(|v| v.safe_slice())
-        }
-        #[inline]
-        pub fn write_version(&self) -> u64 {
-            self._tab
-                .get::<u64>(AccountInfo::VT_WRITE_VERSION, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn slot(&self) -> u64 {
-            self._tab.get::<u64>(AccountInfo::VT_SLOT, Some(0)).unwrap()
-        }
-        #[inline]
-        pub fn is_startup(&self) -> bool {
-            self._tab
-                .get::<bool>(AccountInfo::VT_IS_STARTUP, Some(false))
-                .unwrap()
-        }
-    }
 
-    impl flatbuffers::Verifiable for AccountInfo<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                    "pubkey",
-                    Self::VT_PUBKEY,
-                    false,
-                )?
-                .visit_field::<u64>("lamports", Self::VT_LAMPORTS, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                    "owner",
-                    Self::VT_OWNER,
-                    false,
-                )?
-                .visit_field::<bool>("executable", Self::VT_EXECUTABLE, false)?
-                .visit_field::<u64>("rent_epoch", Self::VT_RENT_EPOCH, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                    "data",
-                    Self::VT_DATA,
-                    false,
-                )?
-                .visit_field::<u64>("write_version", Self::VT_WRITE_VERSION, false)?
-                .visit_field::<u64>("slot", Self::VT_SLOT, false)?
-                .visit_field::<bool>("is_startup", Self::VT_IS_STARTUP, false)?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct AccountInfoArgs<'a> {
-        pub pubkey: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-        pub lamports: u64,
-        pub owner: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-        pub executable: bool,
-        pub rent_epoch: u64,
-        pub data: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-        pub write_version: u64,
-        pub slot: u64,
-        pub is_startup: bool,
-    }
-    impl<'a> Default for AccountInfoArgs<'a> {
-        #[inline]
-        fn default() -> Self {
-            AccountInfoArgs {
-                pubkey: None,
-                lamports: 0,
-                owner: None,
-                executable: false,
-                rent_epoch: 0,
-                data: None,
-                write_version: 0,
-                slot: 0,
-                is_startup: false,
-            }
-        }
-    }
+  #[inline]
+  pub fn pubkey(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(AccountInfo::VT_PUBKEY, None).map(|v| v.safe_slice())
+  }
+  #[inline]
+  pub fn lamports(&self) -> u64 {
+    self._tab.get::<u64>(AccountInfo::VT_LAMPORTS, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn owner(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(AccountInfo::VT_OWNER, None).map(|v| v.safe_slice())
+  }
+  #[inline]
+  pub fn executable(&self) -> bool {
+    self._tab.get::<bool>(AccountInfo::VT_EXECUTABLE, Some(false)).unwrap()
+  }
+  #[inline]
+  pub fn rent_epoch(&self) -> u64 {
+    self._tab.get::<u64>(AccountInfo::VT_RENT_EPOCH, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn data(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(AccountInfo::VT_DATA, None).map(|v| v.safe_slice())
+  }
+  #[inline]
+  pub fn write_version(&self) -> u64 {
+    self._tab.get::<u64>(AccountInfo::VT_WRITE_VERSION, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn slot(&self) -> u64 {
+    self._tab.get::<u64>(AccountInfo::VT_SLOT, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn is_startup(&self) -> bool {
+    self._tab.get::<bool>(AccountInfo::VT_IS_STARTUP, Some(false)).unwrap()
+  }
+}
 
-    pub struct AccountInfoBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+impl flatbuffers::Verifiable for AccountInfo<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("pubkey", Self::VT_PUBKEY, false)?
+     .visit_field::<u64>("lamports", Self::VT_LAMPORTS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("owner", Self::VT_OWNER, false)?
+     .visit_field::<bool>("executable", Self::VT_EXECUTABLE, false)?
+     .visit_field::<u64>("rent_epoch", Self::VT_RENT_EPOCH, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("data", Self::VT_DATA, false)?
+     .visit_field::<u64>("write_version", Self::VT_WRITE_VERSION, false)?
+     .visit_field::<u64>("slot", Self::VT_SLOT, false)?
+     .visit_field::<bool>("is_startup", Self::VT_IS_STARTUP, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct AccountInfoArgs<'a> {
+    pub pubkey: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub lamports: u64,
+    pub owner: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub executable: bool,
+    pub rent_epoch: u64,
+    pub data: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub write_version: u64,
+    pub slot: u64,
+    pub is_startup: bool,
+}
+impl<'a> Default for AccountInfoArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    AccountInfoArgs {
+      pubkey: None,
+      lamports: 0,
+      owner: None,
+      executable: false,
+      rent_epoch: 0,
+      data: None,
+      write_version: 0,
+      slot: 0,
+      is_startup: false,
     }
-    impl<'a: 'b, 'b> AccountInfoBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_pubkey(&mut self, pubkey: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(AccountInfo::VT_PUBKEY, pubkey);
-        }
-        #[inline]
-        pub fn add_lamports(&mut self, lamports: u64) {
-            self.fbb_
-                .push_slot::<u64>(AccountInfo::VT_LAMPORTS, lamports, 0);
-        }
-        #[inline]
-        pub fn add_owner(&mut self, owner: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(AccountInfo::VT_OWNER, owner);
-        }
-        #[inline]
-        pub fn add_executable(&mut self, executable: bool) {
-            self.fbb_
-                .push_slot::<bool>(AccountInfo::VT_EXECUTABLE, executable, false);
-        }
-        #[inline]
-        pub fn add_rent_epoch(&mut self, rent_epoch: u64) {
-            self.fbb_
-                .push_slot::<u64>(AccountInfo::VT_RENT_EPOCH, rent_epoch, 0);
-        }
-        #[inline]
-        pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(AccountInfo::VT_DATA, data);
-        }
-        #[inline]
-        pub fn add_write_version(&mut self, write_version: u64) {
-            self.fbb_
-                .push_slot::<u64>(AccountInfo::VT_WRITE_VERSION, write_version, 0);
-        }
-        #[inline]
-        pub fn add_slot(&mut self, slot: u64) {
-            self.fbb_.push_slot::<u64>(AccountInfo::VT_SLOT, slot, 0);
-        }
-        #[inline]
-        pub fn add_is_startup(&mut self, is_startup: bool) {
-            self.fbb_
-                .push_slot::<bool>(AccountInfo::VT_IS_STARTUP, is_startup, false);
-        }
-        #[inline]
-        pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AccountInfoBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            AccountInfoBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<AccountInfo<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
+  }
+}
 
-    impl core::fmt::Debug for AccountInfo<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("AccountInfo");
-            ds.field("pubkey", &self.pubkey());
-            ds.field("lamports", &self.lamports());
-            ds.field("owner", &self.owner());
-            ds.field("executable", &self.executable());
-            ds.field("rent_epoch", &self.rent_epoch());
-            ds.field("data", &self.data());
-            ds.field("write_version", &self.write_version());
-            ds.field("slot", &self.slot());
-            ds.field("is_startup", &self.is_startup());
-            ds.finish()
-        }
+pub struct AccountInfoBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> AccountInfoBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_pubkey(&mut self, pubkey: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AccountInfo::VT_PUBKEY, pubkey);
+  }
+  #[inline]
+  pub fn add_lamports(&mut self, lamports: u64) {
+    self.fbb_.push_slot::<u64>(AccountInfo::VT_LAMPORTS, lamports, 0);
+  }
+  #[inline]
+  pub fn add_owner(&mut self, owner: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AccountInfo::VT_OWNER, owner);
+  }
+  #[inline]
+  pub fn add_executable(&mut self, executable: bool) {
+    self.fbb_.push_slot::<bool>(AccountInfo::VT_EXECUTABLE, executable, false);
+  }
+  #[inline]
+  pub fn add_rent_epoch(&mut self, rent_epoch: u64) {
+    self.fbb_.push_slot::<u64>(AccountInfo::VT_RENT_EPOCH, rent_epoch, 0);
+  }
+  #[inline]
+  pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AccountInfo::VT_DATA, data);
+  }
+  #[inline]
+  pub fn add_write_version(&mut self, write_version: u64) {
+    self.fbb_.push_slot::<u64>(AccountInfo::VT_WRITE_VERSION, write_version, 0);
+  }
+  #[inline]
+  pub fn add_slot(&mut self, slot: u64) {
+    self.fbb_.push_slot::<u64>(AccountInfo::VT_SLOT, slot, 0);
+  }
+  #[inline]
+  pub fn add_is_startup(&mut self, is_startup: bool) {
+    self.fbb_.push_slot::<bool>(AccountInfo::VT_IS_STARTUP, is_startup, false);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AccountInfoBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    AccountInfoBuilder {
+      fbb_: _fbb,
+      start_: start,
     }
-    #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_root_as_account_info<'a>(buf: &'a [u8]) -> AccountInfo<'a> {
-        unsafe { flatbuffers::root_unchecked::<AccountInfo<'a>>(buf) }
-    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<AccountInfo<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
 
-    #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_size_prefixed_root_as_account_info<'a>(buf: &'a [u8]) -> AccountInfo<'a> {
-        unsafe { flatbuffers::size_prefixed_root_unchecked::<AccountInfo<'a>>(buf) }
-    }
+impl core::fmt::Debug for AccountInfo<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("AccountInfo");
+      ds.field("pubkey", &self.pubkey());
+      ds.field("lamports", &self.lamports());
+      ds.field("owner", &self.owner());
+      ds.field("executable", &self.executable());
+      ds.field("rent_epoch", &self.rent_epoch());
+      ds.field("data", &self.data());
+      ds.field("write_version", &self.write_version());
+      ds.field("slot", &self.slot());
+      ds.field("is_startup", &self.is_startup());
+      ds.finish()
+  }
+}
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_root_as_account_info<'a>(buf: &'a [u8]) -> AccountInfo<'a> {
+  unsafe { flatbuffers::root_unchecked::<AccountInfo<'a>>(buf) }
+}
 
-    #[inline]
-    /// Verifies that a buffer of bytes contains a `AccountInfo`
-    /// and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_account_info_unchecked`.
-    pub fn root_as_account_info(buf: &[u8]) -> Result<AccountInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root::<AccountInfo>(buf)
-    }
-    #[inline]
-    /// Verifies that a buffer of bytes contains a size prefixed
-    /// `AccountInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `size_prefixed_root_as_account_info_unchecked`.
-    pub fn size_prefixed_root_as_account_info(
-        buf: &[u8],
-    ) -> Result<AccountInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root::<AccountInfo>(buf)
-    }
-    #[inline]
-    /// Verifies, with the given options, that a buffer of bytes
-    /// contains a `AccountInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_account_info_unchecked`.
-    pub fn root_as_account_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<AccountInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root_with_opts::<AccountInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Verifies, with the given verifier options, that a buffer of
-    /// bytes contains a size prefixed `AccountInfo` and returns
-    /// it. Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_account_info_unchecked`.
-    pub fn size_prefixed_root_as_account_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<AccountInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root_with_opts::<AccountInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a AccountInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid `AccountInfo`.
-    pub unsafe fn root_as_account_info_unchecked(buf: &[u8]) -> AccountInfo {
-        flatbuffers::root_unchecked::<AccountInfo>(buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a size prefixed AccountInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid size prefixed `AccountInfo`.
-    pub unsafe fn size_prefixed_root_as_account_info_unchecked(buf: &[u8]) -> AccountInfo {
-        flatbuffers::size_prefixed_root_unchecked::<AccountInfo>(buf)
-    }
-    #[inline]
-    pub fn finish_account_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<AccountInfo<'a>>,
-    ) {
-        fbb.finish(root, None);
-    }
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_size_prefixed_root_as_account_info<'a>(buf: &'a [u8]) -> AccountInfo<'a> {
+  unsafe { flatbuffers::size_prefixed_root_unchecked::<AccountInfo<'a>>(buf) }
+}
 
-    #[inline]
-    pub fn finish_size_prefixed_account_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<AccountInfo<'a>>,
-    ) {
-        fbb.finish_size_prefixed(root, None);
-    }
-} // pub mod AccountInfo
+#[inline]
+/// Verifies that a buffer of bytes contains a `AccountInfo`
+/// and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_account_info_unchecked`.
+pub fn root_as_account_info(buf: &[u8]) -> Result<AccountInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root::<AccountInfo>(buf)
+}
+#[inline]
+/// Verifies that a buffer of bytes contains a size prefixed
+/// `AccountInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `size_prefixed_root_as_account_info_unchecked`.
+pub fn size_prefixed_root_as_account_info(buf: &[u8]) -> Result<AccountInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root::<AccountInfo>(buf)
+}
+#[inline]
+/// Verifies, with the given options, that a buffer of bytes
+/// contains a `AccountInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_account_info_unchecked`.
+pub fn root_as_account_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<AccountInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root_with_opts::<AccountInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Verifies, with the given verifier options, that a buffer of
+/// bytes contains a size prefixed `AccountInfo` and returns
+/// it. Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_account_info_unchecked`.
+pub fn size_prefixed_root_as_account_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<AccountInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root_with_opts::<AccountInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a AccountInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid `AccountInfo`.
+pub unsafe fn root_as_account_info_unchecked(buf: &[u8]) -> AccountInfo {
+  flatbuffers::root_unchecked::<AccountInfo>(buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a size prefixed AccountInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid size prefixed `AccountInfo`.
+pub unsafe fn size_prefixed_root_as_account_info_unchecked(buf: &[u8]) -> AccountInfo {
+  flatbuffers::size_prefixed_root_unchecked::<AccountInfo>(buf)
+}
+#[inline]
+pub fn finish_account_info_buffer<'a, 'b>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    root: flatbuffers::WIPOffset<AccountInfo<'a>>) {
+  fbb.finish(root, None);
+}
+
+#[inline]
+pub fn finish_size_prefixed_account_info_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<AccountInfo<'a>>) {
+  fbb.finish_size_prefixed(root, None);
+}
+}  // pub mod AccountInfo
+

--- a/plerkle_serialization/src/block_info_generated.rs
+++ b/plerkle_serialization/src/block_info_generated.rs
@@ -2,564 +2,498 @@
 
 
 
+use core::mem;
+use core::cmp::Ordering;
 
 extern crate flatbuffers;
-
+use self::flatbuffers::{EndianScalar, Follow};
 
 #[allow(unused_imports, dead_code)]
 pub mod block_info {
 
-    use core::cmp::Ordering;
-    use core::mem;
+  use core::mem;
+  use core::cmp::Ordering;
 
-    extern crate flatbuffers;
-    use self::flatbuffers::{EndianScalar, Follow};
+  extern crate flatbuffers;
+  use self::flatbuffers::{EndianScalar, Follow};
 
-    #[deprecated(
-        since = "2.0.0",
-        note = "Use associated constants instead. This will no longer be generated in 2021."
-    )]
-    pub const ENUM_MIN_REWARD_TYPE: u8 = 0;
-    #[deprecated(
-        since = "2.0.0",
-        note = "Use associated constants instead. This will no longer be generated in 2021."
-    )]
-    pub const ENUM_MAX_REWARD_TYPE: u8 = 3;
-    #[deprecated(
-        since = "2.0.0",
-        note = "Use associated constants instead. This will no longer be generated in 2021."
-    )]
-    #[allow(non_camel_case_types)]
-    pub const ENUM_VALUES_REWARD_TYPE: [RewardType; 4] = [
-        RewardType::Fee,
-        RewardType::Rent,
-        RewardType::Staking,
-        RewardType::Voting,
-    ];
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MIN_REWARD_TYPE: u8 = 0;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MAX_REWARD_TYPE: u8 = 3;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_REWARD_TYPE: [RewardType; 4] = [
+  RewardType::Fee,
+  RewardType::Rent,
+  RewardType::Staking,
+  RewardType::Voting,
+];
 
-    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-    #[repr(transparent)]
-    pub struct RewardType(pub u8);
-    #[allow(non_upper_case_globals)]
-    impl RewardType {
-        pub const Fee: Self = Self(0);
-        pub const Rent: Self = Self(1);
-        pub const Staking: Self = Self(2);
-        pub const Voting: Self = Self(3);
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct RewardType(pub u8);
+#[allow(non_upper_case_globals)]
+impl RewardType {
+  pub const Fee: Self = Self(0);
+  pub const Rent: Self = Self(1);
+  pub const Staking: Self = Self(2);
+  pub const Voting: Self = Self(3);
 
-        pub const ENUM_MIN: u8 = 0;
-        pub const ENUM_MAX: u8 = 3;
-        pub const ENUM_VALUES: &'static [Self] =
-            &[Self::Fee, Self::Rent, Self::Staking, Self::Voting];
-        /// Returns the variant's name or "" if unknown.
-        pub fn variant_name(self) -> Option<&'static str> {
-            match self {
-                Self::Fee => Some("Fee"),
-                Self::Rent => Some("Rent"),
-                Self::Staking => Some("Staking"),
-                Self::Voting => Some("Voting"),
-                _ => None,
-            }
-        }
+  pub const ENUM_MIN: u8 = 0;
+  pub const ENUM_MAX: u8 = 3;
+  pub const ENUM_VALUES: &'static [Self] = &[
+    Self::Fee,
+    Self::Rent,
+    Self::Staking,
+    Self::Voting,
+  ];
+  /// Returns the variant's name or "" if unknown.
+  pub fn variant_name(self) -> Option<&'static str> {
+    match self {
+      Self::Fee => Some("Fee"),
+      Self::Rent => Some("Rent"),
+      Self::Staking => Some("Staking"),
+      Self::Voting => Some("Voting"),
+      _ => None,
     }
-    impl core::fmt::Debug for RewardType {
-        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-            if let Some(name) = self.variant_name() {
-                f.write_str(name)
-            } else {
-                f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
-            }
-        }
+  }
+}
+impl core::fmt::Debug for RewardType {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    if let Some(name) = self.variant_name() {
+      f.write_str(name)
+    } else {
+      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
     }
-    impl<'a> flatbuffers::Follow<'a> for RewardType {
-        type Inner = Self;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
-            Self(b)
-        }
-    }
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for RewardType {
+  type Inner = Self;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    let b = unsafe {
+      flatbuffers::read_scalar_at::<u8>(buf, loc)
+    };
+    Self(b)
+  }
+}
 
-    impl flatbuffers::Push for RewardType {
-        type Output = RewardType;
-        #[inline]
-        fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-            unsafe {
-                flatbuffers::emplace_scalar::<u8>(dst, self.0);
-            }
-        }
-    }
-
-    impl flatbuffers::EndianScalar for RewardType {
-        #[inline]
-        fn to_little_endian(self) -> Self {
-            let b = u8::to_le(self.0);
-            Self(b)
-        }
-        #[inline]
-        #[allow(clippy::wrong_self_convention)]
-        fn from_little_endian(self) -> Self {
-            let b = u8::from_le(self.0);
-            Self(b)
-        }
-    }
-
-    impl<'a> flatbuffers::Verifiable for RewardType {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            u8::run_verifier(v, pos)
-        }
-    }
-
-    impl flatbuffers::SimpleToVerifyInSlice for RewardType {}
-    pub enum RewardOffset {}
-    #[derive(Copy, Clone, PartialEq)]
-
-    pub struct Reward<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
-
-    impl<'a> flatbuffers::Follow<'a> for Reward<'a> {
-        type Inner = Reward<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
-
-    impl<'a> Reward<'a> {
-        pub const VT_PUBKEY: flatbuffers::VOffsetT = 4;
-        pub const VT_LAMPORTS: flatbuffers::VOffsetT = 6;
-        pub const VT_POST_BALANCE: flatbuffers::VOffsetT = 8;
-        pub const VT_REWARD_TYPE: flatbuffers::VOffsetT = 10;
-        pub const VT_COMMISSION: flatbuffers::VOffsetT = 12;
-
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            Reward { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args RewardArgs<'args>,
-        ) -> flatbuffers::WIPOffset<Reward<'bldr>> {
-            let mut builder = RewardBuilder::new(_fbb);
-            builder.add_post_balance(args.post_balance);
-            builder.add_lamports(args.lamports);
-            if let Some(x) = args.pubkey {
-                builder.add_pubkey(x);
-            }
-            if let Some(x) = args.commission {
-                builder.add_commission(x);
-            }
-            if let Some(x) = args.reward_type {
-                builder.add_reward_type(x);
-            }
-            builder.finish()
-        }
-
-        #[inline]
-        pub fn pubkey(&self) -> Option<&'a [u8]> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    Reward::VT_PUBKEY,
-                    None,
-                )
-                .map(|v| v.safe_slice())
-        }
-        #[inline]
-        pub fn lamports(&self) -> i64 {
-            self._tab.get::<i64>(Reward::VT_LAMPORTS, Some(0)).unwrap()
-        }
-        #[inline]
-        pub fn post_balance(&self) -> u64 {
-            self._tab
-                .get::<u64>(Reward::VT_POST_BALANCE, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn reward_type(&self) -> Option<RewardType> {
-            self._tab.get::<RewardType>(Reward::VT_REWARD_TYPE, None)
-        }
-        #[inline]
-        pub fn commission(&self) -> Option<u8> {
-            self._tab.get::<u8>(Reward::VT_COMMISSION, None)
-        }
-    }
-
-    impl flatbuffers::Verifiable for Reward<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                    "pubkey",
-                    Self::VT_PUBKEY,
-                    false,
-                )?
-                .visit_field::<i64>("lamports", Self::VT_LAMPORTS, false)?
-                .visit_field::<u64>("post_balance", Self::VT_POST_BALANCE, false)?
-                .visit_field::<RewardType>("reward_type", Self::VT_REWARD_TYPE, false)?
-                .visit_field::<u8>("commission", Self::VT_COMMISSION, false)?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct RewardArgs<'a> {
-        pub pubkey: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-        pub lamports: i64,
-        pub post_balance: u64,
-        pub reward_type: Option<RewardType>,
-        pub commission: Option<u8>,
-    }
-    impl<'a> Default for RewardArgs<'a> {
-        #[inline]
-        fn default() -> Self {
-            RewardArgs {
-                pubkey: None,
-                lamports: 0,
-                post_balance: 0,
-                reward_type: None,
-                commission: None,
-            }
-        }
-    }
-
-    pub struct RewardBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-    }
-    impl<'a: 'b, 'b> RewardBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_pubkey(&mut self, pubkey: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(Reward::VT_PUBKEY, pubkey);
-        }
-        #[inline]
-        pub fn add_lamports(&mut self, lamports: i64) {
-            self.fbb_.push_slot::<i64>(Reward::VT_LAMPORTS, lamports, 0);
-        }
-        #[inline]
-        pub fn add_post_balance(&mut self, post_balance: u64) {
-            self.fbb_
-                .push_slot::<u64>(Reward::VT_POST_BALANCE, post_balance, 0);
-        }
-        #[inline]
-        pub fn add_reward_type(&mut self, reward_type: RewardType) {
-            self.fbb_
-                .push_slot_always::<RewardType>(Reward::VT_REWARD_TYPE, reward_type);
-        }
-        #[inline]
-        pub fn add_commission(&mut self, commission: u8) {
-            self.fbb_
-                .push_slot_always::<u8>(Reward::VT_COMMISSION, commission);
-        }
-        #[inline]
-        pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> RewardBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            RewardBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<Reward<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
-
-    impl core::fmt::Debug for Reward<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("Reward");
-            ds.field("pubkey", &self.pubkey());
-            ds.field("lamports", &self.lamports());
-            ds.field("post_balance", &self.post_balance());
-            ds.field("reward_type", &self.reward_type());
-            ds.field("commission", &self.commission());
-            ds.finish()
-        }
-    }
-    pub enum BlockInfoOffset {}
-    #[derive(Copy, Clone, PartialEq)]
-
-    pub struct BlockInfo<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
-
-    impl<'a> flatbuffers::Follow<'a> for BlockInfo<'a> {
-        type Inner = BlockInfo<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
-
-    impl<'a> BlockInfo<'a> {
-        pub const VT_SLOT: flatbuffers::VOffsetT = 4;
-        pub const VT_BLOCKHASH: flatbuffers::VOffsetT = 6;
-        pub const VT_REWARDS: flatbuffers::VOffsetT = 8;
-        pub const VT_BLOCK_TIME: flatbuffers::VOffsetT = 10;
-        pub const VT_BLOCK_HEIGHT: flatbuffers::VOffsetT = 12;
-
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            BlockInfo { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args BlockInfoArgs<'args>,
-        ) -> flatbuffers::WIPOffset<BlockInfo<'bldr>> {
-            let mut builder = BlockInfoBuilder::new(_fbb);
-            if let Some(x) = args.block_height {
-                builder.add_block_height(x);
-            }
-            if let Some(x) = args.block_time {
-                builder.add_block_time(x);
-            }
-            builder.add_slot(args.slot);
-            if let Some(x) = args.rewards {
-                builder.add_rewards(x);
-            }
-            if let Some(x) = args.blockhash {
-                builder.add_blockhash(x);
-            }
-            builder.finish()
-        }
-
-        #[inline]
-        pub fn slot(&self) -> u64 {
-            self._tab.get::<u64>(BlockInfo::VT_SLOT, Some(0)).unwrap()
-        }
-        #[inline]
-        pub fn blockhash(&self) -> Option<&'a str> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(BlockInfo::VT_BLOCKHASH, None)
-        }
-        #[inline]
-        pub fn rewards(
-            &self,
-        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Reward<'a>>>> {
-            self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Reward>>,
-            >>(BlockInfo::VT_REWARDS, None)
-        }
-        #[inline]
-        pub fn block_time(&self) -> Option<i64> {
-            self._tab.get::<i64>(BlockInfo::VT_BLOCK_TIME, None)
-        }
-        #[inline]
-        pub fn block_height(&self) -> Option<u64> {
-            self._tab.get::<u64>(BlockInfo::VT_BLOCK_HEIGHT, None)
-        }
-    }
-
-    impl flatbuffers::Verifiable for BlockInfo<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<u64>("slot", Self::VT_SLOT, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                    "blockhash",
-                    Self::VT_BLOCKHASH,
-                    false,
-                )?
-                .visit_field::<flatbuffers::ForwardsUOffset<
-                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Reward>>,
-                >>("rewards", Self::VT_REWARDS, false)?
-                .visit_field::<i64>("block_time", Self::VT_BLOCK_TIME, false)?
-                .visit_field::<u64>("block_height", Self::VT_BLOCK_HEIGHT, false)?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct BlockInfoArgs<'a> {
-        pub slot: u64,
-        pub blockhash: Option<flatbuffers::WIPOffset<&'a str>>,
-        pub rewards: Option<
-            flatbuffers::WIPOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Reward<'a>>>,
-            >,
-        >,
-        pub block_time: Option<i64>,
-        pub block_height: Option<u64>,
-    }
-    impl<'a> Default for BlockInfoArgs<'a> {
-        #[inline]
-        fn default() -> Self {
-            BlockInfoArgs {
-                slot: 0,
-                blockhash: None,
-                rewards: None,
-                block_time: None,
-                block_height: None,
-            }
-        }
-    }
-
-    pub struct BlockInfoBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-    }
-    impl<'a: 'b, 'b> BlockInfoBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_slot(&mut self, slot: u64) {
-            self.fbb_.push_slot::<u64>(BlockInfo::VT_SLOT, slot, 0);
-        }
-        #[inline]
-        pub fn add_blockhash(&mut self, blockhash: flatbuffers::WIPOffset<&'b str>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(BlockInfo::VT_BLOCKHASH, blockhash);
-        }
-        #[inline]
-        pub fn add_rewards(
-            &mut self,
-            rewards: flatbuffers::WIPOffset<
-                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Reward<'b>>>,
-            >,
-        ) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(BlockInfo::VT_REWARDS, rewards);
-        }
-        #[inline]
-        pub fn add_block_time(&mut self, block_time: i64) {
-            self.fbb_
-                .push_slot_always::<i64>(BlockInfo::VT_BLOCK_TIME, block_time);
-        }
-        #[inline]
-        pub fn add_block_height(&mut self, block_height: u64) {
-            self.fbb_
-                .push_slot_always::<u64>(BlockInfo::VT_BLOCK_HEIGHT, block_height);
-        }
-        #[inline]
-        pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> BlockInfoBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            BlockInfoBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<BlockInfo<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
-
-    impl core::fmt::Debug for BlockInfo<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("BlockInfo");
-            ds.field("slot", &self.slot());
-            ds.field("blockhash", &self.blockhash());
-            ds.field("rewards", &self.rewards());
-            ds.field("block_time", &self.block_time());
-            ds.field("block_height", &self.block_height());
-            ds.finish()
-        }
-    }
+impl flatbuffers::Push for RewardType {
+    type Output = RewardType;
     #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_root_as_block_info<'a>(buf: &'a [u8]) -> BlockInfo<'a> {
-        unsafe { flatbuffers::root_unchecked::<BlockInfo<'a>>(buf) }
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        unsafe { flatbuffers::emplace_scalar::<u8>(dst, self.0); }
     }
+}
 
-    #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_size_prefixed_root_as_block_info<'a>(buf: &'a [u8]) -> BlockInfo<'a> {
-        unsafe { flatbuffers::size_prefixed_root_unchecked::<BlockInfo<'a>>(buf) }
-    }
+impl flatbuffers::EndianScalar for RewardType {
+  #[inline]
+  fn to_little_endian(self) -> Self {
+    let b = u8::to_le(self.0);
+    Self(b)
+  }
+  #[inline]
+  #[allow(clippy::wrong_self_convention)]
+  fn from_little_endian(self) -> Self {
+    let b = u8::from_le(self.0);
+    Self(b)
+  }
+}
 
-    #[inline]
-    /// Verifies that a buffer of bytes contains a `BlockInfo`
-    /// and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_block_info_unchecked`.
-    pub fn root_as_block_info(buf: &[u8]) -> Result<BlockInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root::<BlockInfo>(buf)
-    }
-    #[inline]
-    /// Verifies that a buffer of bytes contains a size prefixed
-    /// `BlockInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `size_prefixed_root_as_block_info_unchecked`.
-    pub fn size_prefixed_root_as_block_info(
-        buf: &[u8],
-    ) -> Result<BlockInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root::<BlockInfo>(buf)
-    }
-    #[inline]
-    /// Verifies, with the given options, that a buffer of bytes
-    /// contains a `BlockInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_block_info_unchecked`.
-    pub fn root_as_block_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<BlockInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root_with_opts::<BlockInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Verifies, with the given verifier options, that a buffer of
-    /// bytes contains a size prefixed `BlockInfo` and returns
-    /// it. Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_block_info_unchecked`.
-    pub fn size_prefixed_root_as_block_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<BlockInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root_with_opts::<BlockInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a BlockInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid `BlockInfo`.
-    pub unsafe fn root_as_block_info_unchecked(buf: &[u8]) -> BlockInfo {
-        flatbuffers::root_unchecked::<BlockInfo>(buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a size prefixed BlockInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid size prefixed `BlockInfo`.
-    pub unsafe fn size_prefixed_root_as_block_info_unchecked(buf: &[u8]) -> BlockInfo {
-        flatbuffers::size_prefixed_root_unchecked::<BlockInfo>(buf)
-    }
-    #[inline]
-    pub fn finish_block_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<BlockInfo<'a>>,
-    ) {
-        fbb.finish(root, None);
-    }
+impl<'a> flatbuffers::Verifiable for RewardType {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    u8::run_verifier(v, pos)
+  }
+}
 
-    #[inline]
-    pub fn finish_size_prefixed_block_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<BlockInfo<'a>>,
-    ) {
-        fbb.finish_size_prefixed(root, None);
+impl flatbuffers::SimpleToVerifyInSlice for RewardType {}
+pub enum RewardOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct Reward<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Reward<'a> {
+  type Inner = Reward<'a>;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table { buf, loc } }
+  }
+}
+
+impl<'a> Reward<'a> {
+  pub const VT_PUBKEY: flatbuffers::VOffsetT = 4;
+  pub const VT_LAMPORTS: flatbuffers::VOffsetT = 6;
+  pub const VT_POST_BALANCE: flatbuffers::VOffsetT = 8;
+  pub const VT_REWARD_TYPE: flatbuffers::VOffsetT = 10;
+  pub const VT_COMMISSION: flatbuffers::VOffsetT = 12;
+
+  #[inline]
+  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    Reward { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+    args: &'args RewardArgs<'args>
+  ) -> flatbuffers::WIPOffset<Reward<'bldr>> {
+    let mut builder = RewardBuilder::new(_fbb);
+    builder.add_post_balance(args.post_balance);
+    builder.add_lamports(args.lamports);
+    if let Some(x) = args.pubkey { builder.add_pubkey(x); }
+    if let Some(x) = args.commission { builder.add_commission(x); }
+    if let Some(x) = args.reward_type { builder.add_reward_type(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn pubkey(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(Reward::VT_PUBKEY, None).map(|v| v.safe_slice())
+  }
+  #[inline]
+  pub fn lamports(&self) -> i64 {
+    self._tab.get::<i64>(Reward::VT_LAMPORTS, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn post_balance(&self) -> u64 {
+    self._tab.get::<u64>(Reward::VT_POST_BALANCE, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn reward_type(&self) -> Option<RewardType> {
+    self._tab.get::<RewardType>(Reward::VT_REWARD_TYPE, None)
+  }
+  #[inline]
+  pub fn commission(&self) -> Option<u8> {
+    self._tab.get::<u8>(Reward::VT_COMMISSION, None)
+  }
+}
+
+impl flatbuffers::Verifiable for Reward<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("pubkey", Self::VT_PUBKEY, false)?
+     .visit_field::<i64>("lamports", Self::VT_LAMPORTS, false)?
+     .visit_field::<u64>("post_balance", Self::VT_POST_BALANCE, false)?
+     .visit_field::<RewardType>("reward_type", Self::VT_REWARD_TYPE, false)?
+     .visit_field::<u8>("commission", Self::VT_COMMISSION, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct RewardArgs<'a> {
+    pub pubkey: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub lamports: i64,
+    pub post_balance: u64,
+    pub reward_type: Option<RewardType>,
+    pub commission: Option<u8>,
+}
+impl<'a> Default for RewardArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    RewardArgs {
+      pubkey: None,
+      lamports: 0,
+      post_balance: 0,
+      reward_type: None,
+      commission: None,
     }
-} // pub mod BlockInfo
+  }
+}
+
+pub struct RewardBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> RewardBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_pubkey(&mut self, pubkey: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Reward::VT_PUBKEY, pubkey);
+  }
+  #[inline]
+  pub fn add_lamports(&mut self, lamports: i64) {
+    self.fbb_.push_slot::<i64>(Reward::VT_LAMPORTS, lamports, 0);
+  }
+  #[inline]
+  pub fn add_post_balance(&mut self, post_balance: u64) {
+    self.fbb_.push_slot::<u64>(Reward::VT_POST_BALANCE, post_balance, 0);
+  }
+  #[inline]
+  pub fn add_reward_type(&mut self, reward_type: RewardType) {
+    self.fbb_.push_slot_always::<RewardType>(Reward::VT_REWARD_TYPE, reward_type);
+  }
+  #[inline]
+  pub fn add_commission(&mut self, commission: u8) {
+    self.fbb_.push_slot_always::<u8>(Reward::VT_COMMISSION, commission);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> RewardBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    RewardBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Reward<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for Reward<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("Reward");
+      ds.field("pubkey", &self.pubkey());
+      ds.field("lamports", &self.lamports());
+      ds.field("post_balance", &self.post_balance());
+      ds.field("reward_type", &self.reward_type());
+      ds.field("commission", &self.commission());
+      ds.finish()
+  }
+}
+pub enum BlockInfoOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct BlockInfo<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for BlockInfo<'a> {
+  type Inner = BlockInfo<'a>;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table { buf, loc } }
+  }
+}
+
+impl<'a> BlockInfo<'a> {
+  pub const VT_SLOT: flatbuffers::VOffsetT = 4;
+  pub const VT_BLOCKHASH: flatbuffers::VOffsetT = 6;
+  pub const VT_REWARDS: flatbuffers::VOffsetT = 8;
+  pub const VT_BLOCK_TIME: flatbuffers::VOffsetT = 10;
+  pub const VT_BLOCK_HEIGHT: flatbuffers::VOffsetT = 12;
+
+  #[inline]
+  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    BlockInfo { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+    args: &'args BlockInfoArgs<'args>
+  ) -> flatbuffers::WIPOffset<BlockInfo<'bldr>> {
+    let mut builder = BlockInfoBuilder::new(_fbb);
+    if let Some(x) = args.block_height { builder.add_block_height(x); }
+    if let Some(x) = args.block_time { builder.add_block_time(x); }
+    builder.add_slot(args.slot);
+    if let Some(x) = args.rewards { builder.add_rewards(x); }
+    if let Some(x) = args.blockhash { builder.add_blockhash(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn slot(&self) -> u64 {
+    self._tab.get::<u64>(BlockInfo::VT_SLOT, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn blockhash(&self) -> Option<&'a str> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(BlockInfo::VT_BLOCKHASH, None)
+  }
+  #[inline]
+  pub fn rewards(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Reward<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Reward>>>>(BlockInfo::VT_REWARDS, None)
+  }
+  #[inline]
+  pub fn block_time(&self) -> Option<i64> {
+    self._tab.get::<i64>(BlockInfo::VT_BLOCK_TIME, None)
+  }
+  #[inline]
+  pub fn block_height(&self) -> Option<u64> {
+    self._tab.get::<u64>(BlockInfo::VT_BLOCK_HEIGHT, None)
+  }
+}
+
+impl flatbuffers::Verifiable for BlockInfo<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u64>("slot", Self::VT_SLOT, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("blockhash", Self::VT_BLOCKHASH, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Reward>>>>("rewards", Self::VT_REWARDS, false)?
+     .visit_field::<i64>("block_time", Self::VT_BLOCK_TIME, false)?
+     .visit_field::<u64>("block_height", Self::VT_BLOCK_HEIGHT, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct BlockInfoArgs<'a> {
+    pub slot: u64,
+    pub blockhash: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub rewards: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Reward<'a>>>>>,
+    pub block_time: Option<i64>,
+    pub block_height: Option<u64>,
+}
+impl<'a> Default for BlockInfoArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    BlockInfoArgs {
+      slot: 0,
+      blockhash: None,
+      rewards: None,
+      block_time: None,
+      block_height: None,
+    }
+  }
+}
+
+pub struct BlockInfoBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> BlockInfoBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_slot(&mut self, slot: u64) {
+    self.fbb_.push_slot::<u64>(BlockInfo::VT_SLOT, slot, 0);
+  }
+  #[inline]
+  pub fn add_blockhash(&mut self, blockhash: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(BlockInfo::VT_BLOCKHASH, blockhash);
+  }
+  #[inline]
+  pub fn add_rewards(&mut self, rewards: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Reward<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(BlockInfo::VT_REWARDS, rewards);
+  }
+  #[inline]
+  pub fn add_block_time(&mut self, block_time: i64) {
+    self.fbb_.push_slot_always::<i64>(BlockInfo::VT_BLOCK_TIME, block_time);
+  }
+  #[inline]
+  pub fn add_block_height(&mut self, block_height: u64) {
+    self.fbb_.push_slot_always::<u64>(BlockInfo::VT_BLOCK_HEIGHT, block_height);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> BlockInfoBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    BlockInfoBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<BlockInfo<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for BlockInfo<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("BlockInfo");
+      ds.field("slot", &self.slot());
+      ds.field("blockhash", &self.blockhash());
+      ds.field("rewards", &self.rewards());
+      ds.field("block_time", &self.block_time());
+      ds.field("block_height", &self.block_height());
+      ds.finish()
+  }
+}
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_root_as_block_info<'a>(buf: &'a [u8]) -> BlockInfo<'a> {
+  unsafe { flatbuffers::root_unchecked::<BlockInfo<'a>>(buf) }
+}
+
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_size_prefixed_root_as_block_info<'a>(buf: &'a [u8]) -> BlockInfo<'a> {
+  unsafe { flatbuffers::size_prefixed_root_unchecked::<BlockInfo<'a>>(buf) }
+}
+
+#[inline]
+/// Verifies that a buffer of bytes contains a `BlockInfo`
+/// and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_block_info_unchecked`.
+pub fn root_as_block_info(buf: &[u8]) -> Result<BlockInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root::<BlockInfo>(buf)
+}
+#[inline]
+/// Verifies that a buffer of bytes contains a size prefixed
+/// `BlockInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `size_prefixed_root_as_block_info_unchecked`.
+pub fn size_prefixed_root_as_block_info(buf: &[u8]) -> Result<BlockInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root::<BlockInfo>(buf)
+}
+#[inline]
+/// Verifies, with the given options, that a buffer of bytes
+/// contains a `BlockInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_block_info_unchecked`.
+pub fn root_as_block_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<BlockInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root_with_opts::<BlockInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Verifies, with the given verifier options, that a buffer of
+/// bytes contains a size prefixed `BlockInfo` and returns
+/// it. Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_block_info_unchecked`.
+pub fn size_prefixed_root_as_block_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<BlockInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root_with_opts::<BlockInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a BlockInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid `BlockInfo`.
+pub unsafe fn root_as_block_info_unchecked(buf: &[u8]) -> BlockInfo {
+  flatbuffers::root_unchecked::<BlockInfo>(buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a size prefixed BlockInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid size prefixed `BlockInfo`.
+pub unsafe fn size_prefixed_root_as_block_info_unchecked(buf: &[u8]) -> BlockInfo {
+  flatbuffers::size_prefixed_root_unchecked::<BlockInfo>(buf)
+}
+#[inline]
+pub fn finish_block_info_buffer<'a, 'b>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    root: flatbuffers::WIPOffset<BlockInfo<'a>>) {
+  fbb.finish(root, None);
+}
+
+#[inline]
+pub fn finish_size_prefixed_block_info_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<BlockInfo<'a>>) {
+  fbb.finish_size_prefixed(root, None);
+}
+}  // pub mod BlockInfo
+

--- a/plerkle_serialization/src/lib.rs
+++ b/plerkle_serialization/src/lib.rs
@@ -2,5 +2,3 @@ pub mod account_info_generated;
 pub mod block_info_generated;
 pub mod slot_status_info_generated;
 pub mod transaction_info_generated;
-
-//TODO -> Add From and TO pubkey for flatbuffer key

--- a/plerkle_serialization/src/slot_status_info_generated.rs
+++ b/plerkle_serialization/src/slot_status_info_generated.rs
@@ -2,336 +2,316 @@
 
 
 
+use core::mem;
+use core::cmp::Ordering;
 
 extern crate flatbuffers;
-
+use self::flatbuffers::{EndianScalar, Follow};
 
 #[allow(unused_imports, dead_code)]
 pub mod slot_status_info {
 
-    use core::cmp::Ordering;
-    use core::mem;
+  use core::mem;
+  use core::cmp::Ordering;
 
-    extern crate flatbuffers;
-    use self::flatbuffers::{EndianScalar, Follow};
+  extern crate flatbuffers;
+  use self::flatbuffers::{EndianScalar, Follow};
 
-    #[deprecated(
-        since = "2.0.0",
-        note = "Use associated constants instead. This will no longer be generated in 2021."
-    )]
-    pub const ENUM_MIN_STATUS: i8 = 0;
-    #[deprecated(
-        since = "2.0.0",
-        note = "Use associated constants instead. This will no longer be generated in 2021."
-    )]
-    pub const ENUM_MAX_STATUS: i8 = 2;
-    #[deprecated(
-        since = "2.0.0",
-        note = "Use associated constants instead. This will no longer be generated in 2021."
-    )]
-    #[allow(non_camel_case_types)]
-    pub const ENUM_VALUES_STATUS: [Status; 3] =
-        [Status::Processed, Status::Rooted, Status::Confirmed];
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MIN_STATUS: i8 = 0;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MAX_STATUS: i8 = 2;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_STATUS: [Status; 3] = [
+  Status::Processed,
+  Status::Rooted,
+  Status::Confirmed,
+];
 
-    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-    #[repr(transparent)]
-    pub struct Status(pub i8);
-    #[allow(non_upper_case_globals)]
-    impl Status {
-        pub const Processed: Self = Self(0);
-        pub const Rooted: Self = Self(1);
-        pub const Confirmed: Self = Self(2);
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct Status(pub i8);
+#[allow(non_upper_case_globals)]
+impl Status {
+  pub const Processed: Self = Self(0);
+  pub const Rooted: Self = Self(1);
+  pub const Confirmed: Self = Self(2);
 
-        pub const ENUM_MIN: i8 = 0;
-        pub const ENUM_MAX: i8 = 2;
-        pub const ENUM_VALUES: &'static [Self] = &[Self::Processed, Self::Rooted, Self::Confirmed];
-        /// Returns the variant's name or "" if unknown.
-        pub fn variant_name(self) -> Option<&'static str> {
-            match self {
-                Self::Processed => Some("Processed"),
-                Self::Rooted => Some("Rooted"),
-                Self::Confirmed => Some("Confirmed"),
-                _ => None,
-            }
-        }
+  pub const ENUM_MIN: i8 = 0;
+  pub const ENUM_MAX: i8 = 2;
+  pub const ENUM_VALUES: &'static [Self] = &[
+    Self::Processed,
+    Self::Rooted,
+    Self::Confirmed,
+  ];
+  /// Returns the variant's name or "" if unknown.
+  pub fn variant_name(self) -> Option<&'static str> {
+    match self {
+      Self::Processed => Some("Processed"),
+      Self::Rooted => Some("Rooted"),
+      Self::Confirmed => Some("Confirmed"),
+      _ => None,
     }
-    impl core::fmt::Debug for Status {
-        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-            if let Some(name) = self.variant_name() {
-                f.write_str(name)
-            } else {
-                f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
-            }
-        }
+  }
+}
+impl core::fmt::Debug for Status {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    if let Some(name) = self.variant_name() {
+      f.write_str(name)
+    } else {
+      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
     }
-    impl<'a> flatbuffers::Follow<'a> for Status {
-        type Inner = Self;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            let b = unsafe { flatbuffers::read_scalar_at::<i8>(buf, loc) };
-            Self(b)
-        }
-    }
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for Status {
+  type Inner = Self;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    let b = unsafe {
+      flatbuffers::read_scalar_at::<i8>(buf, loc)
+    };
+    Self(b)
+  }
+}
 
-    impl flatbuffers::Push for Status {
-        type Output = Status;
-        #[inline]
-        fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-            unsafe {
-                flatbuffers::emplace_scalar::<i8>(dst, self.0);
-            }
-        }
-    }
-
-    impl flatbuffers::EndianScalar for Status {
-        #[inline]
-        fn to_little_endian(self) -> Self {
-            let b = i8::to_le(self.0);
-            Self(b)
-        }
-        #[inline]
-        #[allow(clippy::wrong_self_convention)]
-        fn from_little_endian(self) -> Self {
-            let b = i8::from_le(self.0);
-            Self(b)
-        }
-    }
-
-    impl<'a> flatbuffers::Verifiable for Status {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            i8::run_verifier(v, pos)
-        }
-    }
-
-    impl flatbuffers::SimpleToVerifyInSlice for Status {}
-    pub enum SlotStatusInfoOffset {}
-    #[derive(Copy, Clone, PartialEq)]
-
-    pub struct SlotStatusInfo<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
-
-    impl<'a> flatbuffers::Follow<'a> for SlotStatusInfo<'a> {
-        type Inner = SlotStatusInfo<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
-
-    impl<'a> SlotStatusInfo<'a> {
-        pub const VT_SLOT: flatbuffers::VOffsetT = 4;
-        pub const VT_PARENT: flatbuffers::VOffsetT = 6;
-        pub const VT_STATUS: flatbuffers::VOffsetT = 8;
-
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            SlotStatusInfo { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args SlotStatusInfoArgs,
-        ) -> flatbuffers::WIPOffset<SlotStatusInfo<'bldr>> {
-            let mut builder = SlotStatusInfoBuilder::new(_fbb);
-            if let Some(x) = args.parent {
-                builder.add_parent(x);
-            }
-            builder.add_slot(args.slot);
-            builder.add_status(args.status);
-            builder.finish()
-        }
-
-        #[inline]
-        pub fn slot(&self) -> u64 {
-            self._tab
-                .get::<u64>(SlotStatusInfo::VT_SLOT, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn parent(&self) -> Option<u64> {
-            self._tab.get::<u64>(SlotStatusInfo::VT_PARENT, None)
-        }
-        #[inline]
-        pub fn status(&self) -> Status {
-            self._tab
-                .get::<Status>(SlotStatusInfo::VT_STATUS, Some(Status::Processed))
-                .unwrap()
-        }
-    }
-
-    impl flatbuffers::Verifiable for SlotStatusInfo<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<u64>("slot", Self::VT_SLOT, false)?
-                .visit_field::<u64>("parent", Self::VT_PARENT, false)?
-                .visit_field::<Status>("status", Self::VT_STATUS, false)?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct SlotStatusInfoArgs {
-        pub slot: u64,
-        pub parent: Option<u64>,
-        pub status: Status,
-    }
-    impl<'a> Default for SlotStatusInfoArgs {
-        #[inline]
-        fn default() -> Self {
-            SlotStatusInfoArgs {
-                slot: 0,
-                parent: None,
-                status: Status::Processed,
-            }
-        }
-    }
-
-    pub struct SlotStatusInfoBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-    }
-    impl<'a: 'b, 'b> SlotStatusInfoBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_slot(&mut self, slot: u64) {
-            self.fbb_.push_slot::<u64>(SlotStatusInfo::VT_SLOT, slot, 0);
-        }
-        #[inline]
-        pub fn add_parent(&mut self, parent: u64) {
-            self.fbb_
-                .push_slot_always::<u64>(SlotStatusInfo::VT_PARENT, parent);
-        }
-        #[inline]
-        pub fn add_status(&mut self, status: Status) {
-            self.fbb_
-                .push_slot::<Status>(SlotStatusInfo::VT_STATUS, status, Status::Processed);
-        }
-        #[inline]
-        pub fn new(
-            _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        ) -> SlotStatusInfoBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            SlotStatusInfoBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<SlotStatusInfo<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
-
-    impl core::fmt::Debug for SlotStatusInfo<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("SlotStatusInfo");
-            ds.field("slot", &self.slot());
-            ds.field("parent", &self.parent());
-            ds.field("status", &self.status());
-            ds.finish()
-        }
-    }
+impl flatbuffers::Push for Status {
+    type Output = Status;
     #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_root_as_slot_status_info<'a>(buf: &'a [u8]) -> SlotStatusInfo<'a> {
-        unsafe { flatbuffers::root_unchecked::<SlotStatusInfo<'a>>(buf) }
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        unsafe { flatbuffers::emplace_scalar::<i8>(dst, self.0); }
     }
+}
 
-    #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_size_prefixed_root_as_slot_status_info<'a>(buf: &'a [u8]) -> SlotStatusInfo<'a> {
-        unsafe { flatbuffers::size_prefixed_root_unchecked::<SlotStatusInfo<'a>>(buf) }
-    }
+impl flatbuffers::EndianScalar for Status {
+  #[inline]
+  fn to_little_endian(self) -> Self {
+    let b = i8::to_le(self.0);
+    Self(b)
+  }
+  #[inline]
+  #[allow(clippy::wrong_self_convention)]
+  fn from_little_endian(self) -> Self {
+    let b = i8::from_le(self.0);
+    Self(b)
+  }
+}
 
-    #[inline]
-    /// Verifies that a buffer of bytes contains a `SlotStatusInfo`
-    /// and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_slot_status_info_unchecked`.
-    pub fn root_as_slot_status_info(
-        buf: &[u8],
-    ) -> Result<SlotStatusInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root::<SlotStatusInfo>(buf)
-    }
-    #[inline]
-    /// Verifies that a buffer of bytes contains a size prefixed
-    /// `SlotStatusInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `size_prefixed_root_as_slot_status_info_unchecked`.
-    pub fn size_prefixed_root_as_slot_status_info(
-        buf: &[u8],
-    ) -> Result<SlotStatusInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root::<SlotStatusInfo>(buf)
-    }
-    #[inline]
-    /// Verifies, with the given options, that a buffer of bytes
-    /// contains a `SlotStatusInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_slot_status_info_unchecked`.
-    pub fn root_as_slot_status_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<SlotStatusInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root_with_opts::<SlotStatusInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Verifies, with the given verifier options, that a buffer of
-    /// bytes contains a size prefixed `SlotStatusInfo` and returns
-    /// it. Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_slot_status_info_unchecked`.
-    pub fn size_prefixed_root_as_slot_status_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<SlotStatusInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root_with_opts::<SlotStatusInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a SlotStatusInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid `SlotStatusInfo`.
-    pub unsafe fn root_as_slot_status_info_unchecked(buf: &[u8]) -> SlotStatusInfo {
-        flatbuffers::root_unchecked::<SlotStatusInfo>(buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a size prefixed SlotStatusInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid size prefixed `SlotStatusInfo`.
-    pub unsafe fn size_prefixed_root_as_slot_status_info_unchecked(buf: &[u8]) -> SlotStatusInfo {
-        flatbuffers::size_prefixed_root_unchecked::<SlotStatusInfo>(buf)
-    }
-    #[inline]
-    pub fn finish_slot_status_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<SlotStatusInfo<'a>>,
-    ) {
-        fbb.finish(root, None);
-    }
+impl<'a> flatbuffers::Verifiable for Status {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    i8::run_verifier(v, pos)
+  }
+}
 
-    #[inline]
-    pub fn finish_size_prefixed_slot_status_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<SlotStatusInfo<'a>>,
-    ) {
-        fbb.finish_size_prefixed(root, None);
+impl flatbuffers::SimpleToVerifyInSlice for Status {}
+pub enum SlotStatusInfoOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct SlotStatusInfo<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for SlotStatusInfo<'a> {
+  type Inner = SlotStatusInfo<'a>;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table { buf, loc } }
+  }
+}
+
+impl<'a> SlotStatusInfo<'a> {
+  pub const VT_SLOT: flatbuffers::VOffsetT = 4;
+  pub const VT_PARENT: flatbuffers::VOffsetT = 6;
+  pub const VT_STATUS: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    SlotStatusInfo { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+    args: &'args SlotStatusInfoArgs
+  ) -> flatbuffers::WIPOffset<SlotStatusInfo<'bldr>> {
+    let mut builder = SlotStatusInfoBuilder::new(_fbb);
+    if let Some(x) = args.parent { builder.add_parent(x); }
+    builder.add_slot(args.slot);
+    builder.add_status(args.status);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn slot(&self) -> u64 {
+    self._tab.get::<u64>(SlotStatusInfo::VT_SLOT, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn parent(&self) -> Option<u64> {
+    self._tab.get::<u64>(SlotStatusInfo::VT_PARENT, None)
+  }
+  #[inline]
+  pub fn status(&self) -> Status {
+    self._tab.get::<Status>(SlotStatusInfo::VT_STATUS, Some(Status::Processed)).unwrap()
+  }
+}
+
+impl flatbuffers::Verifiable for SlotStatusInfo<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u64>("slot", Self::VT_SLOT, false)?
+     .visit_field::<u64>("parent", Self::VT_PARENT, false)?
+     .visit_field::<Status>("status", Self::VT_STATUS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct SlotStatusInfoArgs {
+    pub slot: u64,
+    pub parent: Option<u64>,
+    pub status: Status,
+}
+impl<'a> Default for SlotStatusInfoArgs {
+  #[inline]
+  fn default() -> Self {
+    SlotStatusInfoArgs {
+      slot: 0,
+      parent: None,
+      status: Status::Processed,
     }
-} // pub mod SlotStatusInfo
+  }
+}
+
+pub struct SlotStatusInfoBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> SlotStatusInfoBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_slot(&mut self, slot: u64) {
+    self.fbb_.push_slot::<u64>(SlotStatusInfo::VT_SLOT, slot, 0);
+  }
+  #[inline]
+  pub fn add_parent(&mut self, parent: u64) {
+    self.fbb_.push_slot_always::<u64>(SlotStatusInfo::VT_PARENT, parent);
+  }
+  #[inline]
+  pub fn add_status(&mut self, status: Status) {
+    self.fbb_.push_slot::<Status>(SlotStatusInfo::VT_STATUS, status, Status::Processed);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> SlotStatusInfoBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    SlotStatusInfoBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<SlotStatusInfo<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for SlotStatusInfo<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("SlotStatusInfo");
+      ds.field("slot", &self.slot());
+      ds.field("parent", &self.parent());
+      ds.field("status", &self.status());
+      ds.finish()
+  }
+}
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_root_as_slot_status_info<'a>(buf: &'a [u8]) -> SlotStatusInfo<'a> {
+  unsafe { flatbuffers::root_unchecked::<SlotStatusInfo<'a>>(buf) }
+}
+
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_size_prefixed_root_as_slot_status_info<'a>(buf: &'a [u8]) -> SlotStatusInfo<'a> {
+  unsafe { flatbuffers::size_prefixed_root_unchecked::<SlotStatusInfo<'a>>(buf) }
+}
+
+#[inline]
+/// Verifies that a buffer of bytes contains a `SlotStatusInfo`
+/// and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_slot_status_info_unchecked`.
+pub fn root_as_slot_status_info(buf: &[u8]) -> Result<SlotStatusInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root::<SlotStatusInfo>(buf)
+}
+#[inline]
+/// Verifies that a buffer of bytes contains a size prefixed
+/// `SlotStatusInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `size_prefixed_root_as_slot_status_info_unchecked`.
+pub fn size_prefixed_root_as_slot_status_info(buf: &[u8]) -> Result<SlotStatusInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root::<SlotStatusInfo>(buf)
+}
+#[inline]
+/// Verifies, with the given options, that a buffer of bytes
+/// contains a `SlotStatusInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_slot_status_info_unchecked`.
+pub fn root_as_slot_status_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<SlotStatusInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root_with_opts::<SlotStatusInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Verifies, with the given verifier options, that a buffer of
+/// bytes contains a size prefixed `SlotStatusInfo` and returns
+/// it. Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_slot_status_info_unchecked`.
+pub fn size_prefixed_root_as_slot_status_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<SlotStatusInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root_with_opts::<SlotStatusInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a SlotStatusInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid `SlotStatusInfo`.
+pub unsafe fn root_as_slot_status_info_unchecked(buf: &[u8]) -> SlotStatusInfo {
+  flatbuffers::root_unchecked::<SlotStatusInfo>(buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a size prefixed SlotStatusInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid size prefixed `SlotStatusInfo`.
+pub unsafe fn size_prefixed_root_as_slot_status_info_unchecked(buf: &[u8]) -> SlotStatusInfo {
+  flatbuffers::size_prefixed_root_unchecked::<SlotStatusInfo>(buf)
+}
+#[inline]
+pub fn finish_slot_status_info_buffer<'a, 'b>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    root: flatbuffers::WIPOffset<SlotStatusInfo<'a>>) {
+  fbb.finish(root, None);
+}
+
+#[inline]
+pub fn finish_size_prefixed_slot_status_info_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<SlotStatusInfo<'a>>) {
+  fbb.finish_size_prefixed(root, None);
+}
+}  // pub mod SlotStatusInfo
+

--- a/plerkle_serialization/src/transaction_info_generated.rs
+++ b/plerkle_serialization/src/transaction_info_generated.rs
@@ -2,806 +2,610 @@
 
 
 
+use core::mem;
+use core::cmp::Ordering;
 
 extern crate flatbuffers;
-
+use self::flatbuffers::{EndianScalar, Follow};
 
 #[allow(unused_imports, dead_code)]
 pub mod transaction_info {
 
-    use core::cmp::Ordering;
-    use core::mem;
+  use core::mem;
+  use core::cmp::Ordering;
 
-    extern crate flatbuffers;
-    use self::flatbuffers::{EndianScalar, Follow};
+  extern crate flatbuffers;
+  use self::flatbuffers::{EndianScalar, Follow};
 
-    pub enum TransactionInfoOffset {}
-    #[derive(Copy, Clone, PartialEq)]
+// struct Pubkey, aligned to 1
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq)]
+pub struct Pubkey(pub [u8; 32]);
+impl Default for Pubkey { 
+  fn default() -> Self { 
+    Self([0; 32])
+  }
+}
+impl core::fmt::Debug for Pubkey {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    f.debug_struct("Pubkey")
+      .field("key", &self.key())
+      .finish()
+  }
+}
 
-    pub struct TransactionInfo<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
-
-    impl<'a> flatbuffers::Follow<'a> for TransactionInfo<'a> {
-        type Inner = TransactionInfo<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
-
-    impl<'a> TransactionInfo<'a> {
-        pub const VT_IS_VOTE: flatbuffers::VOffsetT = 4;
-        pub const VT_ACCOUNT_KEYS: flatbuffers::VOffsetT = 6;
-        pub const VT_LOG_MESSAGES: flatbuffers::VOffsetT = 8;
-        pub const VT_INNER_INSTRUCTIONS: flatbuffers::VOffsetT = 10;
-        pub const VT_OUTER_INSTRUCTIONS: flatbuffers::VOffsetT = 12;
-        pub const VT_SLOT: flatbuffers::VOffsetT = 14;
-        pub const VT_SLOT_INDEX: flatbuffers::VOffsetT = 16;
-        pub const VT_SEEN_AT: flatbuffers::VOffsetT = 18;
-
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            TransactionInfo { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args TransactionInfoArgs<'args>,
-        ) -> flatbuffers::WIPOffset<TransactionInfo<'bldr>> {
-            let mut builder = TransactionInfoBuilder::new(_fbb);
-            builder.add_seen_at(args.seen_at);
-            builder.add_slot(args.slot);
-            if let Some(x) = args.slot_index {
-                builder.add_slot_index(x);
-            }
-            if let Some(x) = args.outer_instructions {
-                builder.add_outer_instructions(x);
-            }
-            if let Some(x) = args.inner_instructions {
-                builder.add_inner_instructions(x);
-            }
-            if let Some(x) = args.log_messages {
-                builder.add_log_messages(x);
-            }
-            if let Some(x) = args.account_keys {
-                builder.add_account_keys(x);
-            }
-            builder.add_is_vote(args.is_vote);
-            builder.finish()
-        }
-
-        #[inline]
-        pub fn is_vote(&self) -> bool {
-            self._tab
-                .get::<bool>(TransactionInfo::VT_IS_VOTE, Some(false))
-                .unwrap()
-        }
-        #[inline]
-        pub fn account_keys(
-            &self,
-        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Pubkey<'a>>>> {
-            self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Pubkey>>,
-            >>(TransactionInfo::VT_ACCOUNT_KEYS, None)
-        }
-        #[inline]
-        pub fn log_messages(
-            &self,
-        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>> {
-            self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>,
-            >>(TransactionInfo::VT_LOG_MESSAGES, None)
-        }
-        #[inline]
-        pub fn inner_instructions(
-            &self,
-        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InnerInstructions<'a>>>>
-        {
-            self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InnerInstructions>>,
-            >>(TransactionInfo::VT_INNER_INSTRUCTIONS, None)
-        }
-        #[inline]
-        pub fn outer_instructions(
-            &self,
-        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>>
-        {
-            self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction>>,
-            >>(TransactionInfo::VT_OUTER_INSTRUCTIONS, None)
-        }
-        #[inline]
-        pub fn slot(&self) -> u64 {
-            self._tab
-                .get::<u64>(TransactionInfo::VT_SLOT, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn slot_index(&self) -> Option<&'a str> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<&str>>(TransactionInfo::VT_SLOT_INDEX, None)
-        }
-        #[inline]
-        pub fn seen_at(&self) -> i64 {
-            self._tab
-                .get::<i64>(TransactionInfo::VT_SEEN_AT, Some(0))
-                .unwrap()
-        }
-    }
-
-    impl flatbuffers::Verifiable for TransactionInfo<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<bool>("is_vote", Self::VT_IS_VOTE, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<
-                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Pubkey>>,
-                >>("account_keys", Self::VT_ACCOUNT_KEYS, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<
-                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>,
-                >>("log_messages", Self::VT_LOG_MESSAGES, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<
-                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<InnerInstructions>>,
-                >>("inner_instructions", Self::VT_INNER_INSTRUCTIONS, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<
-                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompiledInstruction>>,
-                >>("outer_instructions", Self::VT_OUTER_INSTRUCTIONS, false)?
-                .visit_field::<u64>("slot", Self::VT_SLOT, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
-                    "slot_index",
-                    Self::VT_SLOT_INDEX,
-                    false,
-                )?
-                .visit_field::<i64>("seen_at", Self::VT_SEEN_AT, false)?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct TransactionInfoArgs<'a> {
-        pub is_vote: bool,
-        pub account_keys: Option<
-            flatbuffers::WIPOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Pubkey<'a>>>,
-            >,
-        >,
-        pub log_messages: Option<
-            flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>,
-        >,
-        pub inner_instructions: Option<
-            flatbuffers::WIPOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InnerInstructions<'a>>>,
-            >,
-        >,
-        pub outer_instructions: Option<
-            flatbuffers::WIPOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>,
-            >,
-        >,
-        pub slot: u64,
-        pub slot_index: Option<flatbuffers::WIPOffset<&'a str>>,
-        pub seen_at: i64,
-    }
-    impl<'a> Default for TransactionInfoArgs<'a> {
-        #[inline]
-        fn default() -> Self {
-            TransactionInfoArgs {
-                is_vote: false,
-                account_keys: None,
-                log_messages: None,
-                inner_instructions: None,
-                outer_instructions: None,
-                slot: 0,
-                slot_index: None,
-                seen_at: 0,
-            }
-        }
-    }
-
-    pub struct TransactionInfoBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-    }
-    impl<'a: 'b, 'b> TransactionInfoBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_is_vote(&mut self, is_vote: bool) {
-            self.fbb_
-                .push_slot::<bool>(TransactionInfo::VT_IS_VOTE, is_vote, false);
-        }
-        #[inline]
-        pub fn add_account_keys(
-            &mut self,
-            account_keys: flatbuffers::WIPOffset<
-                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Pubkey<'b>>>,
-            >,
-        ) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                TransactionInfo::VT_ACCOUNT_KEYS,
-                account_keys,
-            );
-        }
-        #[inline]
-        pub fn add_log_messages(
-            &mut self,
-            log_messages: flatbuffers::WIPOffset<
-                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<&'b str>>,
-            >,
-        ) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                TransactionInfo::VT_LOG_MESSAGES,
-                log_messages,
-            );
-        }
-        #[inline]
-        pub fn add_inner_instructions(
-            &mut self,
-            inner_instructions: flatbuffers::WIPOffset<
-                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<InnerInstructions<'b>>>,
-            >,
-        ) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                TransactionInfo::VT_INNER_INSTRUCTIONS,
-                inner_instructions,
-            );
-        }
-        #[inline]
-        pub fn add_outer_instructions(
-            &mut self,
-            outer_instructions: flatbuffers::WIPOffset<
-                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<CompiledInstruction<'b>>>,
-            >,
-        ) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                TransactionInfo::VT_OUTER_INSTRUCTIONS,
-                outer_instructions,
-            );
-        }
-        #[inline]
-        pub fn add_slot(&mut self, slot: u64) {
-            self.fbb_
-                .push_slot::<u64>(TransactionInfo::VT_SLOT, slot, 0);
-        }
-        #[inline]
-        pub fn add_slot_index(&mut self, slot_index: flatbuffers::WIPOffset<&'b str>) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                TransactionInfo::VT_SLOT_INDEX,
-                slot_index,
-            );
-        }
-        #[inline]
-        pub fn add_seen_at(&mut self, seen_at: i64) {
-            self.fbb_
-                .push_slot::<i64>(TransactionInfo::VT_SEEN_AT, seen_at, 0);
-        }
-        #[inline]
-        pub fn new(
-            _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        ) -> TransactionInfoBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            TransactionInfoBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<TransactionInfo<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
-
-    impl core::fmt::Debug for TransactionInfo<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("TransactionInfo");
-            ds.field("is_vote", &self.is_vote());
-            ds.field("account_keys", &self.account_keys());
-            ds.field("log_messages", &self.log_messages());
-            ds.field("inner_instructions", &self.inner_instructions());
-            ds.field("outer_instructions", &self.outer_instructions());
-            ds.field("slot", &self.slot());
-            ds.field("slot_index", &self.slot_index());
-            ds.field("seen_at", &self.seen_at());
-            ds.finish()
-        }
-    }
-    pub enum PubkeyOffset {}
-    #[derive(Copy, Clone, PartialEq)]
-
-    pub struct Pubkey<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
-
-    impl<'a> flatbuffers::Follow<'a> for Pubkey<'a> {
-        type Inner = Pubkey<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
-
-    impl<'a> Pubkey<'a> {
-        pub const VT_KEY: flatbuffers::VOffsetT = 4;
-
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            Pubkey { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args PubkeyArgs<'args>,
-        ) -> flatbuffers::WIPOffset<Pubkey<'bldr>> {
-            let mut builder = PubkeyBuilder::new(_fbb);
-            if let Some(x) = args.key {
-                builder.add_key(x);
-            }
-            builder.finish()
-        }
-
-        #[inline]
-        pub fn key(&self) -> Option<&'a [u8]> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    Pubkey::VT_KEY,
-                    None,
-                )
-                .map(|v| v.safe_slice())
-        }
-    }
-
-    impl flatbuffers::Verifiable for Pubkey<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                    "key",
-                    Self::VT_KEY,
-                    false,
-                )?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct PubkeyArgs<'a> {
-        pub key: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    }
-    impl<'a> Default for PubkeyArgs<'a> {
-        #[inline]
-        fn default() -> Self {
-            PubkeyArgs { key: None }
-        }
-    }
-
-    pub struct PubkeyBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-    }
-    impl<'a: 'b, 'b> PubkeyBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_key(&mut self, key: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(Pubkey::VT_KEY, key);
-        }
-        #[inline]
-        pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PubkeyBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            PubkeyBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<Pubkey<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
-
-    impl core::fmt::Debug for Pubkey<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("Pubkey");
-            ds.field("key", &self.key());
-            ds.finish()
-        }
-    }
-    pub enum CompiledInstructionOffset {}
-    #[derive(Copy, Clone, PartialEq)]
-
-    pub struct CompiledInstruction<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
-
-    impl<'a> flatbuffers::Follow<'a> for CompiledInstruction<'a> {
-        type Inner = CompiledInstruction<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
-
-    impl<'a> CompiledInstruction<'a> {
-        pub const VT_PROGRAM_ID_INDEX: flatbuffers::VOffsetT = 4;
-        pub const VT_ACCOUNTS: flatbuffers::VOffsetT = 6;
-        pub const VT_DATA: flatbuffers::VOffsetT = 8;
-
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            CompiledInstruction { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args CompiledInstructionArgs<'args>,
-        ) -> flatbuffers::WIPOffset<CompiledInstruction<'bldr>> {
-            let mut builder = CompiledInstructionBuilder::new(_fbb);
-            if let Some(x) = args.data {
-                builder.add_data(x);
-            }
-            if let Some(x) = args.accounts {
-                builder.add_accounts(x);
-            }
-            builder.add_program_id_index(args.program_id_index);
-            builder.finish()
-        }
-
-        #[inline]
-        pub fn program_id_index(&self) -> u8 {
-            self._tab
-                .get::<u8>(CompiledInstruction::VT_PROGRAM_ID_INDEX, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn accounts(&self) -> Option<&'a [u8]> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    CompiledInstruction::VT_ACCOUNTS,
-                    None,
-                )
-                .map(|v| v.safe_slice())
-        }
-        #[inline]
-        pub fn data(&self) -> Option<&'a [u8]> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
-                    CompiledInstruction::VT_DATA,
-                    None,
-                )
-                .map(|v| v.safe_slice())
-        }
-    }
-
-    impl flatbuffers::Verifiable for CompiledInstruction<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<u8>("program_id_index", Self::VT_PROGRAM_ID_INDEX, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                    "accounts",
-                    Self::VT_ACCOUNTS,
-                    false,
-                )?
-                .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
-                    "data",
-                    Self::VT_DATA,
-                    false,
-                )?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct CompiledInstructionArgs<'a> {
-        pub program_id_index: u8,
-        pub accounts: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-        pub data: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
-    }
-    impl<'a> Default for CompiledInstructionArgs<'a> {
-        #[inline]
-        fn default() -> Self {
-            CompiledInstructionArgs {
-                program_id_index: 0,
-                accounts: None,
-                data: None,
-            }
-        }
-    }
-
-    pub struct CompiledInstructionBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-    }
-    impl<'a: 'b, 'b> CompiledInstructionBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_program_id_index(&mut self, program_id_index: u8) {
-            self.fbb_.push_slot::<u8>(
-                CompiledInstruction::VT_PROGRAM_ID_INDEX,
-                program_id_index,
-                0,
-            );
-        }
-        #[inline]
-        pub fn add_accounts(
-            &mut self,
-            accounts: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>,
-        ) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                CompiledInstruction::VT_ACCOUNTS,
-                accounts,
-            );
-        }
-        #[inline]
-        pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<_>>(CompiledInstruction::VT_DATA, data);
-        }
-        #[inline]
-        pub fn new(
-            _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        ) -> CompiledInstructionBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            CompiledInstructionBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<CompiledInstruction<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
-
-    impl core::fmt::Debug for CompiledInstruction<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("CompiledInstruction");
-            ds.field("program_id_index", &self.program_id_index());
-            ds.field("accounts", &self.accounts());
-            ds.field("data", &self.data());
-            ds.finish()
-        }
-    }
-    pub enum InnerInstructionsOffset {}
-    #[derive(Copy, Clone, PartialEq)]
-
-    pub struct InnerInstructions<'a> {
-        pub _tab: flatbuffers::Table<'a>,
-    }
-
-    impl<'a> flatbuffers::Follow<'a> for InnerInstructions<'a> {
-        type Inner = InnerInstructions<'a>;
-        #[inline]
-        fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-            Self {
-                _tab: flatbuffers::Table { buf, loc },
-            }
-        }
-    }
-
-    impl<'a> InnerInstructions<'a> {
-        pub const VT_INDEX: flatbuffers::VOffsetT = 4;
-        pub const VT_INSTRUCTIONS: flatbuffers::VOffsetT = 6;
-
-        #[inline]
-        pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-            InnerInstructions { _tab: table }
-        }
-        #[allow(unused_mut)]
-        pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-            _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-            args: &'args InnerInstructionsArgs<'args>,
-        ) -> flatbuffers::WIPOffset<InnerInstructions<'bldr>> {
-            let mut builder = InnerInstructionsBuilder::new(_fbb);
-            if let Some(x) = args.instructions {
-                builder.add_instructions(x);
-            }
-            builder.add_index(args.index);
-            builder.finish()
-        }
-
-        #[inline]
-        pub fn index(&self) -> u8 {
-            self._tab
-                .get::<u8>(InnerInstructions::VT_INDEX, Some(0))
-                .unwrap()
-        }
-        #[inline]
-        pub fn instructions(
-            &self,
-        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>>
-        {
-            self._tab.get::<flatbuffers::ForwardsUOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction>>,
-            >>(InnerInstructions::VT_INSTRUCTIONS, None)
-        }
-    }
-
-    impl flatbuffers::Verifiable for InnerInstructions<'_> {
-        #[inline]
-        fn run_verifier(
-            v: &mut flatbuffers::Verifier,
-            pos: usize,
-        ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-            use self::flatbuffers::Verifiable;
-            v.visit_table(pos)?
-                .visit_field::<u8>("index", Self::VT_INDEX, false)?
-                .visit_field::<flatbuffers::ForwardsUOffset<
-                    flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompiledInstruction>>,
-                >>("instructions", Self::VT_INSTRUCTIONS, false)?
-                .finish();
-            Ok(())
-        }
-    }
-    pub struct InnerInstructionsArgs<'a> {
-        pub index: u8,
-        pub instructions: Option<
-            flatbuffers::WIPOffset<
-                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>,
-            >,
-        >,
-    }
-    impl<'a> Default for InnerInstructionsArgs<'a> {
-        #[inline]
-        fn default() -> Self {
-            InnerInstructionsArgs {
-                index: 0,
-                instructions: None,
-            }
-        }
-    }
-
-    pub struct InnerInstructionsBuilder<'a: 'b, 'b> {
-        fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-    }
-    impl<'a: 'b, 'b> InnerInstructionsBuilder<'a, 'b> {
-        #[inline]
-        pub fn add_index(&mut self, index: u8) {
-            self.fbb_
-                .push_slot::<u8>(InnerInstructions::VT_INDEX, index, 0);
-        }
-        #[inline]
-        pub fn add_instructions(
-            &mut self,
-            instructions: flatbuffers::WIPOffset<
-                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<CompiledInstruction<'b>>>,
-            >,
-        ) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                InnerInstructions::VT_INSTRUCTIONS,
-                instructions,
-            );
-        }
-        #[inline]
-        pub fn new(
-            _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        ) -> InnerInstructionsBuilder<'a, 'b> {
-            let start = _fbb.start_table();
-            InnerInstructionsBuilder {
-                fbb_: _fbb,
-                start_: start,
-            }
-        }
-        #[inline]
-        pub fn finish(self) -> flatbuffers::WIPOffset<InnerInstructions<'a>> {
-            let o = self.fbb_.end_table(self.start_);
-            flatbuffers::WIPOffset::new(o.value())
-        }
-    }
-
-    impl core::fmt::Debug for InnerInstructions<'_> {
-        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            let mut ds = f.debug_struct("InnerInstructions");
-            ds.field("index", &self.index());
-            ds.field("instructions", &self.instructions());
-            ds.finish()
-        }
-    }
+impl flatbuffers::SimpleToVerifyInSlice for Pubkey {}
+impl flatbuffers::SafeSliceAccess for Pubkey {}
+impl<'a> flatbuffers::Follow<'a> for Pubkey {
+  type Inner = &'a Pubkey;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    <&'a Pubkey>::follow(buf, loc)
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for &'a Pubkey {
+  type Inner = &'a Pubkey;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    flatbuffers::follow_cast_ref::<Pubkey>(buf, loc)
+  }
+}
+impl<'b> flatbuffers::Push for Pubkey {
+    type Output = Pubkey;
     #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_root_as_transaction_info<'a>(buf: &'a [u8]) -> TransactionInfo<'a> {
-        unsafe { flatbuffers::root_unchecked::<TransactionInfo<'a>>(buf) }
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        let src = unsafe {
+            ::core::slice::from_raw_parts(self as *const Pubkey as *const u8, Self::size())
+        };
+        dst.copy_from_slice(src);
     }
+}
+impl<'b> flatbuffers::Push for &'b Pubkey {
+    type Output = Pubkey;
 
     #[inline]
-    #[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
-    pub fn get_size_prefixed_root_as_transaction_info<'a>(buf: &'a [u8]) -> TransactionInfo<'a> {
-        unsafe { flatbuffers::size_prefixed_root_unchecked::<TransactionInfo<'a>>(buf) }
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        let src = unsafe {
+            ::core::slice::from_raw_parts(*self as *const Pubkey as *const u8, Self::size())
+        };
+        dst.copy_from_slice(src);
     }
+}
 
-    #[inline]
-    /// Verifies that a buffer of bytes contains a `TransactionInfo`
-    /// and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_transaction_info_unchecked`.
-    pub fn root_as_transaction_info(
-        buf: &[u8],
-    ) -> Result<TransactionInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root::<TransactionInfo>(buf)
-    }
-    #[inline]
-    /// Verifies that a buffer of bytes contains a size prefixed
-    /// `TransactionInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `size_prefixed_root_as_transaction_info_unchecked`.
-    pub fn size_prefixed_root_as_transaction_info(
-        buf: &[u8],
-    ) -> Result<TransactionInfo, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root::<TransactionInfo>(buf)
-    }
-    #[inline]
-    /// Verifies, with the given options, that a buffer of bytes
-    /// contains a `TransactionInfo` and returns it.
-    /// Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_transaction_info_unchecked`.
-    pub fn root_as_transaction_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<TransactionInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::root_with_opts::<TransactionInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Verifies, with the given verifier options, that a buffer of
-    /// bytes contains a size prefixed `TransactionInfo` and returns
-    /// it. Note that verification is still experimental and may not
-    /// catch every error, or be maximally performant. For the
-    /// previous, unchecked, behavior use
-    /// `root_as_transaction_info_unchecked`.
-    pub fn size_prefixed_root_as_transaction_info_with_opts<'b, 'o>(
-        opts: &'o flatbuffers::VerifierOptions,
-        buf: &'b [u8],
-    ) -> Result<TransactionInfo<'b>, flatbuffers::InvalidFlatbuffer> {
-        flatbuffers::size_prefixed_root_with_opts::<TransactionInfo<'b>>(opts, buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a TransactionInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid `TransactionInfo`.
-    pub unsafe fn root_as_transaction_info_unchecked(buf: &[u8]) -> TransactionInfo {
-        flatbuffers::root_unchecked::<TransactionInfo>(buf)
-    }
-    #[inline]
-    /// Assumes, without verification, that a buffer of bytes contains a size prefixed TransactionInfo and returns it.
-    /// # Safety
-    /// Callers must trust the given bytes do indeed contain a valid size prefixed `TransactionInfo`.
-    pub unsafe fn size_prefixed_root_as_transaction_info_unchecked(buf: &[u8]) -> TransactionInfo {
-        flatbuffers::size_prefixed_root_unchecked::<TransactionInfo>(buf)
-    }
-    #[inline]
-    pub fn finish_transaction_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<TransactionInfo<'a>>,
-    ) {
-        fbb.finish(root, None);
-    }
+impl<'a> flatbuffers::Verifiable for Pubkey {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.in_buffer::<Self>(pos)
+  }
+}
 
-    #[inline]
-    pub fn finish_size_prefixed_transaction_info_buffer<'a, 'b>(
-        fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-        root: flatbuffers::WIPOffset<TransactionInfo<'a>>,
-    ) {
-        fbb.finish_size_prefixed(root, None);
+impl<'a> Pubkey {
+  #[allow(clippy::too_many_arguments)]
+  pub fn new(
+    key: &[u8; 32],
+  ) -> Self {
+    let mut s = Self([0; 32]);
+    s.set_key(key);
+    s
+  }
+
+  pub fn key(&'a self) -> flatbuffers::Array<'a, u8, 32> {
+    flatbuffers::Array::follow(&self.0, 0)
+  }
+
+  pub fn set_key(&mut self, items: &[u8; 32]) {
+    flatbuffers::emplace_scalar_array(&mut self.0, 0, items);
+  }
+
+}
+
+pub enum TransactionInfoOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct TransactionInfo<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for TransactionInfo<'a> {
+  type Inner = TransactionInfo<'a>;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table { buf, loc } }
+  }
+}
+
+impl<'a> TransactionInfo<'a> {
+  pub const VT_IS_VOTE: flatbuffers::VOffsetT = 4;
+  pub const VT_ACCOUNT_KEYS: flatbuffers::VOffsetT = 6;
+  pub const VT_LOG_MESSAGES: flatbuffers::VOffsetT = 8;
+  pub const VT_INNER_INSTRUCTIONS: flatbuffers::VOffsetT = 10;
+  pub const VT_OUTER_INSTRUCTIONS: flatbuffers::VOffsetT = 12;
+  pub const VT_SLOT: flatbuffers::VOffsetT = 14;
+  pub const VT_SLOT_INDEX: flatbuffers::VOffsetT = 16;
+  pub const VT_SEEN_AT: flatbuffers::VOffsetT = 18;
+
+  #[inline]
+  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    TransactionInfo { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+    args: &'args TransactionInfoArgs<'args>
+  ) -> flatbuffers::WIPOffset<TransactionInfo<'bldr>> {
+    let mut builder = TransactionInfoBuilder::new(_fbb);
+    builder.add_seen_at(args.seen_at);
+    builder.add_slot(args.slot);
+    if let Some(x) = args.slot_index { builder.add_slot_index(x); }
+    if let Some(x) = args.outer_instructions { builder.add_outer_instructions(x); }
+    if let Some(x) = args.inner_instructions { builder.add_inner_instructions(x); }
+    if let Some(x) = args.log_messages { builder.add_log_messages(x); }
+    if let Some(x) = args.account_keys { builder.add_account_keys(x); }
+    builder.add_is_vote(args.is_vote);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn is_vote(&self) -> bool {
+    self._tab.get::<bool>(TransactionInfo::VT_IS_VOTE, Some(false)).unwrap()
+  }
+  #[inline]
+  pub fn account_keys(&self) -> Option<&'a [Pubkey]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, Pubkey>>>(TransactionInfo::VT_ACCOUNT_KEYS, None).map(|v| v.safe_slice())
+  }
+  #[inline]
+  pub fn log_messages(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>>(TransactionInfo::VT_LOG_MESSAGES, None)
+  }
+  #[inline]
+  pub fn inner_instructions(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InnerInstructions<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InnerInstructions>>>>(TransactionInfo::VT_INNER_INSTRUCTIONS, None)
+  }
+  #[inline]
+  pub fn outer_instructions(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction>>>>(TransactionInfo::VT_OUTER_INSTRUCTIONS, None)
+  }
+  #[inline]
+  pub fn slot(&self) -> u64 {
+    self._tab.get::<u64>(TransactionInfo::VT_SLOT, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn slot_index(&self) -> Option<&'a str> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(TransactionInfo::VT_SLOT_INDEX, None)
+  }
+  #[inline]
+  pub fn seen_at(&self) -> i64 {
+    self._tab.get::<i64>(TransactionInfo::VT_SEEN_AT, Some(0)).unwrap()
+  }
+}
+
+impl flatbuffers::Verifiable for TransactionInfo<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<bool>("is_vote", Self::VT_IS_VOTE, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, Pubkey>>>("account_keys", Self::VT_ACCOUNT_KEYS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<&'_ str>>>>("log_messages", Self::VT_LOG_MESSAGES, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<InnerInstructions>>>>("inner_instructions", Self::VT_INNER_INSTRUCTIONS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompiledInstruction>>>>("outer_instructions", Self::VT_OUTER_INSTRUCTIONS, false)?
+     .visit_field::<u64>("slot", Self::VT_SLOT, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("slot_index", Self::VT_SLOT_INDEX, false)?
+     .visit_field::<i64>("seen_at", Self::VT_SEEN_AT, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct TransactionInfoArgs<'a> {
+    pub is_vote: bool,
+    pub account_keys: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Pubkey>>>,
+    pub log_messages: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>>>,
+    pub inner_instructions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InnerInstructions<'a>>>>>,
+    pub outer_instructions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>>>,
+    pub slot: u64,
+    pub slot_index: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub seen_at: i64,
+}
+impl<'a> Default for TransactionInfoArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    TransactionInfoArgs {
+      is_vote: false,
+      account_keys: None,
+      log_messages: None,
+      inner_instructions: None,
+      outer_instructions: None,
+      slot: 0,
+      slot_index: None,
+      seen_at: 0,
     }
-} // pub mod TransactionInfo
+  }
+}
+
+pub struct TransactionInfoBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> TransactionInfoBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_is_vote(&mut self, is_vote: bool) {
+    self.fbb_.push_slot::<bool>(TransactionInfo::VT_IS_VOTE, is_vote, false);
+  }
+  #[inline]
+  pub fn add_account_keys(&mut self, account_keys: flatbuffers::WIPOffset<flatbuffers::Vector<'b , Pubkey>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TransactionInfo::VT_ACCOUNT_KEYS, account_keys);
+  }
+  #[inline]
+  pub fn add_log_messages(&mut self, log_messages: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<&'b  str>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TransactionInfo::VT_LOG_MESSAGES, log_messages);
+  }
+  #[inline]
+  pub fn add_inner_instructions(&mut self, inner_instructions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<InnerInstructions<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TransactionInfo::VT_INNER_INSTRUCTIONS, inner_instructions);
+  }
+  #[inline]
+  pub fn add_outer_instructions(&mut self, outer_instructions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<CompiledInstruction<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TransactionInfo::VT_OUTER_INSTRUCTIONS, outer_instructions);
+  }
+  #[inline]
+  pub fn add_slot(&mut self, slot: u64) {
+    self.fbb_.push_slot::<u64>(TransactionInfo::VT_SLOT, slot, 0);
+  }
+  #[inline]
+  pub fn add_slot_index(&mut self, slot_index: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TransactionInfo::VT_SLOT_INDEX, slot_index);
+  }
+  #[inline]
+  pub fn add_seen_at(&mut self, seen_at: i64) {
+    self.fbb_.push_slot::<i64>(TransactionInfo::VT_SEEN_AT, seen_at, 0);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TransactionInfoBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    TransactionInfoBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<TransactionInfo<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for TransactionInfo<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("TransactionInfo");
+      ds.field("is_vote", &self.is_vote());
+      ds.field("account_keys", &self.account_keys());
+      ds.field("log_messages", &self.log_messages());
+      ds.field("inner_instructions", &self.inner_instructions());
+      ds.field("outer_instructions", &self.outer_instructions());
+      ds.field("slot", &self.slot());
+      ds.field("slot_index", &self.slot_index());
+      ds.field("seen_at", &self.seen_at());
+      ds.finish()
+  }
+}
+pub enum CompiledInstructionOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct CompiledInstruction<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for CompiledInstruction<'a> {
+  type Inner = CompiledInstruction<'a>;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table { buf, loc } }
+  }
+}
+
+impl<'a> CompiledInstruction<'a> {
+  pub const VT_PROGRAM_ID_INDEX: flatbuffers::VOffsetT = 4;
+  pub const VT_ACCOUNTS: flatbuffers::VOffsetT = 6;
+  pub const VT_DATA: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    CompiledInstruction { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+    args: &'args CompiledInstructionArgs<'args>
+  ) -> flatbuffers::WIPOffset<CompiledInstruction<'bldr>> {
+    let mut builder = CompiledInstructionBuilder::new(_fbb);
+    if let Some(x) = args.data { builder.add_data(x); }
+    if let Some(x) = args.accounts { builder.add_accounts(x); }
+    builder.add_program_id_index(args.program_id_index);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn program_id_index(&self) -> u8 {
+    self._tab.get::<u8>(CompiledInstruction::VT_PROGRAM_ID_INDEX, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn accounts(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(CompiledInstruction::VT_ACCOUNTS, None).map(|v| v.safe_slice())
+  }
+  #[inline]
+  pub fn data(&self) -> Option<&'a [u8]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(CompiledInstruction::VT_DATA, None).map(|v| v.safe_slice())
+  }
+}
+
+impl flatbuffers::Verifiable for CompiledInstruction<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u8>("program_id_index", Self::VT_PROGRAM_ID_INDEX, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("accounts", Self::VT_ACCOUNTS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("data", Self::VT_DATA, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct CompiledInstructionArgs<'a> {
+    pub program_id_index: u8,
+    pub accounts: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub data: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+}
+impl<'a> Default for CompiledInstructionArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    CompiledInstructionArgs {
+      program_id_index: 0,
+      accounts: None,
+      data: None,
+    }
+  }
+}
+
+pub struct CompiledInstructionBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> CompiledInstructionBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_program_id_index(&mut self, program_id_index: u8) {
+    self.fbb_.push_slot::<u8>(CompiledInstruction::VT_PROGRAM_ID_INDEX, program_id_index, 0);
+  }
+  #[inline]
+  pub fn add_accounts(&mut self, accounts: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CompiledInstruction::VT_ACCOUNTS, accounts);
+  }
+  #[inline]
+  pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CompiledInstruction::VT_DATA, data);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> CompiledInstructionBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    CompiledInstructionBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<CompiledInstruction<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for CompiledInstruction<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("CompiledInstruction");
+      ds.field("program_id_index", &self.program_id_index());
+      ds.field("accounts", &self.accounts());
+      ds.field("data", &self.data());
+      ds.finish()
+  }
+}
+pub enum InnerInstructionsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct InnerInstructions<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for InnerInstructions<'a> {
+  type Inner = InnerInstructions<'a>;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table { buf, loc } }
+  }
+}
+
+impl<'a> InnerInstructions<'a> {
+  pub const VT_INDEX: flatbuffers::VOffsetT = 4;
+  pub const VT_INSTRUCTIONS: flatbuffers::VOffsetT = 6;
+
+  #[inline]
+  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    InnerInstructions { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+    args: &'args InnerInstructionsArgs<'args>
+  ) -> flatbuffers::WIPOffset<InnerInstructions<'bldr>> {
+    let mut builder = InnerInstructionsBuilder::new(_fbb);
+    if let Some(x) = args.instructions { builder.add_instructions(x); }
+    builder.add_index(args.index);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn index(&self) -> u8 {
+    self._tab.get::<u8>(InnerInstructions::VT_INDEX, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn instructions(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction>>>>(InnerInstructions::VT_INSTRUCTIONS, None)
+  }
+}
+
+impl flatbuffers::Verifiable for InnerInstructions<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u8>("index", Self::VT_INDEX, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompiledInstruction>>>>("instructions", Self::VT_INSTRUCTIONS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct InnerInstructionsArgs<'a> {
+    pub index: u8,
+    pub instructions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompiledInstruction<'a>>>>>,
+}
+impl<'a> Default for InnerInstructionsArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    InnerInstructionsArgs {
+      index: 0,
+      instructions: None,
+    }
+  }
+}
+
+pub struct InnerInstructionsBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> InnerInstructionsBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_index(&mut self, index: u8) {
+    self.fbb_.push_slot::<u8>(InnerInstructions::VT_INDEX, index, 0);
+  }
+  #[inline]
+  pub fn add_instructions(&mut self, instructions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<CompiledInstruction<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(InnerInstructions::VT_INSTRUCTIONS, instructions);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InnerInstructionsBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    InnerInstructionsBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<InnerInstructions<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for InnerInstructions<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("InnerInstructions");
+      ds.field("index", &self.index());
+      ds.field("instructions", &self.instructions());
+      ds.finish()
+  }
+}
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_root_as_transaction_info<'a>(buf: &'a [u8]) -> TransactionInfo<'a> {
+  unsafe { flatbuffers::root_unchecked::<TransactionInfo<'a>>(buf) }
+}
+
+#[inline]
+#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+pub fn get_size_prefixed_root_as_transaction_info<'a>(buf: &'a [u8]) -> TransactionInfo<'a> {
+  unsafe { flatbuffers::size_prefixed_root_unchecked::<TransactionInfo<'a>>(buf) }
+}
+
+#[inline]
+/// Verifies that a buffer of bytes contains a `TransactionInfo`
+/// and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_transaction_info_unchecked`.
+pub fn root_as_transaction_info(buf: &[u8]) -> Result<TransactionInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root::<TransactionInfo>(buf)
+}
+#[inline]
+/// Verifies that a buffer of bytes contains a size prefixed
+/// `TransactionInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `size_prefixed_root_as_transaction_info_unchecked`.
+pub fn size_prefixed_root_as_transaction_info(buf: &[u8]) -> Result<TransactionInfo, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root::<TransactionInfo>(buf)
+}
+#[inline]
+/// Verifies, with the given options, that a buffer of bytes
+/// contains a `TransactionInfo` and returns it.
+/// Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_transaction_info_unchecked`.
+pub fn root_as_transaction_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<TransactionInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::root_with_opts::<TransactionInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Verifies, with the given verifier options, that a buffer of
+/// bytes contains a size prefixed `TransactionInfo` and returns
+/// it. Note that verification is still experimental and may not
+/// catch every error, or be maximally performant. For the
+/// previous, unchecked, behavior use
+/// `root_as_transaction_info_unchecked`.
+pub fn size_prefixed_root_as_transaction_info_with_opts<'b, 'o>(
+  opts: &'o flatbuffers::VerifierOptions,
+  buf: &'b [u8],
+) -> Result<TransactionInfo<'b>, flatbuffers::InvalidFlatbuffer> {
+  flatbuffers::size_prefixed_root_with_opts::<TransactionInfo<'b>>(opts, buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a TransactionInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid `TransactionInfo`.
+pub unsafe fn root_as_transaction_info_unchecked(buf: &[u8]) -> TransactionInfo {
+  flatbuffers::root_unchecked::<TransactionInfo>(buf)
+}
+#[inline]
+/// Assumes, without verification, that a buffer of bytes contains a size prefixed TransactionInfo and returns it.
+/// # Safety
+/// Callers must trust the given bytes do indeed contain a valid size prefixed `TransactionInfo`.
+pub unsafe fn size_prefixed_root_as_transaction_info_unchecked(buf: &[u8]) -> TransactionInfo {
+  flatbuffers::size_prefixed_root_unchecked::<TransactionInfo>(buf)
+}
+#[inline]
+pub fn finish_transaction_info_buffer<'a, 'b>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    root: flatbuffers::WIPOffset<TransactionInfo<'a>>) {
+  fbb.finish(root, None);
+}
+
+#[inline]
+pub fn finish_size_prefixed_transaction_info_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<TransactionInfo<'a>>) {
+  fbb.finish_size_prefixed(root, None);
+}
+}  // pub mod TransactionInfo
+

--- a/plerkle_serialization/transaction_info.fbs
+++ b/plerkle_serialization/transaction_info.fbs
@@ -13,8 +13,8 @@ table TransactionInfo {
   seen_at: int64;
 }
 
-table Pubkey {
-    key:[uint8];
+struct Pubkey {
+    key:[uint8:32];
 }
 
 table CompiledInstruction {


### PR DESCRIPTION
This makes  pubkey `key` required by using struct which makes api better to work with. Now pubkey is a type over the `[u8;32]` which is the same as solana, instead of having to use a flat buffer builder we can use this since we know it will always be present.