### PR TITLE
Slot purge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plerkle"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "async-trait",
  "base64 0.21.0",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_messenger"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_serialization"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "bs58",
  "chrono",

--- a/plerkle/Cargo.toml
+++ b/plerkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle"
 description = "Geyser plugin with dynamic config reloading, message bus agnostic abstractions and a whole lot of fun."
-version = "1.5.2"
+version = "1.5.3"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"

--- a/plerkle_messenger/Cargo.toml
+++ b/plerkle_messenger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_messenger"
 description = "Metaplex Messenger trait for Geyser plugin producer/consumer patterns."
-version = "1.5.2"
+version = "1.5.3"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"

--- a/plerkle_serialization/Cargo.toml
+++ b/plerkle_serialization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_serialization"
 description = "Metaplex Flatbuffers Plerkle Serialization for Geyser plugin producer/consumer patterns."
-version = "1.5.2"
+version = "1.5.3"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"


### PR DESCRIPTION
Allow setting SLOT_EXPIRY through an env. Currently SLOT_EXPIRY is fixed at 1200, which means that all txns/accounts seen for the last 1200 slots will be stored in memory, causing memory issues when listening to a lot of accounts