### PR TITLE
Configure backfill streams

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test-stable:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set env vars


### PR DESCRIPTION
Backfill stream constants were created but not configured by default, so could not be used.
