### PR TITLE
Update Rust, Solana version and CI runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   IMAGE_NAME: plerkle-test-validator
-  RUST_VERSION: 1.70.0
+  RUST_VERSION: 1.73.0
   SOLANA_VERSION_STABLE: v1.17.20
 jobs:
   release-stable:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
   IMAGE_NAME: plerkle-test-validator
-  RUST_VERSION: 1.69.0
-  SOLANA_VERSION_STABLE: v1.16.6
+  RUST_VERSION: 1.70.0
+  SOLANA_VERSION_STABLE: v1.17.20
 jobs:
   release-stable:
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-20-04-8-cores
     steps:
       - uses: actions/checkout@v2
       - name: Set env vars

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
   IMAGE_NAME: plerkle-test-validator
-  RUST_VERSION: 1.69.0
-  SOLANA_VERSION_STABLE: v1.16.6
+  RUST_VERSION: 1.70.0
+  SOLANA_VERSION_STABLE: v1.17.20
 
 jobs:
   test-stable:
-    runs-on: buildjet-4vcpu-ubuntu-2004
+    runs-on: ubuntu-20-04-8-cores
     steps:
       - uses: actions/checkout@v2
       - name: Set env vars

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   IMAGE_NAME: plerkle-test-validator
-  RUST_VERSION: 1.70.0
+  RUST_VERSION: 1.73.0
   SOLANA_VERSION_STABLE: v1.17.20
 
 jobs:

--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -126,6 +126,15 @@ impl<'a> PlerklePrivateMethods for Plerkle<'a> {
                      block_time: block_info.block_time,
                      block_height: block_info.block_height,
                      executed_transaction_count: 0,
+                },
+            ReplicaBlockInfoVersions::V0_0_3(block_info) => plerkle_serialization::solana_geyser_plugin_interface_shims::ReplicaBlockInfoV2 {
+                    parent_slot: 0,
+                    parent_blockhash: "",
+                    slot: block_info.slot,
+                    blockhash: block_info.blockhash,
+                    block_time: block_info.block_time,
+                    block_height: block_info.block_height,
+                    executed_transaction_count: 0,
                 }
         }
     }


### PR DESCRIPTION
Update Solana to 1.17 and a newer rust.
Update to github hosted CI runner since we deprecated our buildjet runners.
