### PR TITLE
Update versions for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_messenger"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "async-mutex",
  "async-trait",

--- a/Solana.Dockerfile
+++ b/Solana.Dockerfile
@@ -1,4 +1,4 @@
-ARG SOLANA_VERSION=v1.17.5
+ARG SOLANA_VERSION=v1.17.20
 ARG RUST_VERSION=1.73
 FROM rust:$RUST_VERSION-bullseye as builder
 RUN apt-get update \

--- a/plerkle_messenger/Cargo.toml
+++ b/plerkle_messenger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_messenger"
 description = "Metaplex Messenger trait for Geyser plugin producer/consumer patterns."
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"


### PR DESCRIPTION
Update versions so that when I tag it with v1.8.0 the published crates match.

Also update Solana dockerfile to match CI version used.
