### PR TITLE
Update versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,7 +2143,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plerkle"
-version = "1.6.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_messenger"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_serialization"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "bs58",
  "chrono",

--- a/plerkle/Cargo.toml
+++ b/plerkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle"
 description = "Geyser plugin with dynamic config reloading, message bus agnostic abstractions and a whole lot of fun."
-version = "1.7.0"
+version = "1.9.0"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"
@@ -36,7 +36,7 @@ tracing-subscriber = { version = "0.3.16", features = [
   "ansi",
 ] }
 hex = "0.4.3"
-plerkle_messenger = { path = "../plerkle_messenger", version = "1.6.0", features = ["redis"] }
+plerkle_messenger = { path = "../plerkle_messenger", features = ["redis"] }
 flatbuffers = "23.1.21"
 plerkle_serialization = { path = "../plerkle_serialization", version = "1.6.0" }
 tokio = { version = "1.23.0", features = ["full"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.75.0"


### PR DESCRIPTION
I think since we tag the releases we might as well have all packages have consistent versions, so updated plerkle plugin to also be 1.9.0.

Also updated Rust toolchain file and Cargo.lock file.