### PR TITLE
Update to latest resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "plerkle",
     "plerkle_serialization"
 ]
+resolver = "2"


### PR DESCRIPTION
Just updates to the latest and removes a Cargo warning.
