### PR TITLE
MTG-888 Fix snapshot etl

### DIFF
--- a/plerkle/src/geyser_plugin_nft.rs
+++ b/plerkle/src/geyser_plugin_nft.rs
@@ -496,7 +496,7 @@ impl GeyserPlugin for Plerkle<'static> {
         slot: u64,
         is_startup: bool,
     ) -> solana_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-        if !self.snapshot_parsing && !self.handle_startup && is_startup {
+        if !self.handle_startup && is_startup {
             return Ok(());
         }
         let rep: plerkle_serialization::solana_geyser_plugin_interface_shims::ReplicaAccountInfoV2;

--- a/plerkle_snapshot/src/bin/solana-snapshot-etl/geyser.rs
+++ b/plerkle_snapshot/src/bin/solana-snapshot-etl/geyser.rs
@@ -64,7 +64,7 @@ impl GeyserDumper {
                 write_version: account.meta.write_version,
             }),
             slot,
-            /* is_startup */ true,
+            /* is_startup */ false,
         )?;
         self.accounts_count += 1;
         if self.accounts_count % 1024 == 0 {

--- a/plerkle_snapshot/src/bin/solana-snapshot-etl/geyser.rs
+++ b/plerkle_snapshot/src/bin/solana-snapshot-etl/geyser.rs
@@ -64,7 +64,7 @@ impl GeyserDumper {
                 write_version: account.meta.write_version,
             }),
             slot,
-            /* is_startup */ false,
+            /* is_startup */ true,
         )?;
         self.accounts_count += 1;
         if self.accounts_count % 1024 == 0 {

--- a/plerkle_snapshot/src/bin/solana-snapshot-etl/main.rs
+++ b/plerkle_snapshot/src/bin/solana-snapshot-etl/main.rs
@@ -116,7 +116,7 @@ unsafe fn load_plugin_inner(
     type PluginConstructor = unsafe fn() -> *mut dyn GeyserPlugin;
     // Load library and leak, as we never want to unload it.
     let lib = Box::leak(Box::new(Library::new(libpath)?));
-    let constructor: Symbol<PluginConstructor> = lib.get(b"_create_plugin")?;
+    let constructor: Symbol<PluginConstructor> = lib.get(b"_create_etl_plugin")?;
     // Unsafe call down to library.
     let plugin_raw = constructor();
     let mut plugin = Box::from_raw(plugin_raw);


### PR DESCRIPTION
# What
This PR adds small fix for Solana snapshot ETL. Before this fix accounts which ETL streems was saved to the cache instead of instant write to the Redis.