### PR TITLE
feat(etl): add stream length checks to prevent overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,7 +2984,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plerkle"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "async-trait",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_messenger"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_snapshot"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "async-trait",

--- a/plerkle/Cargo.toml
+++ b/plerkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle"
 description = "Geyser plugin with dynamic config reloading, message bus agnostic abstractions and a whole lot of fun."
-version = "1.10.0"
+version = "1.11.0"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"

--- a/plerkle_messenger/Cargo.toml
+++ b/plerkle_messenger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_messenger"
 description = "Metaplex Messenger trait for Geyser plugin producer/consumer patterns."
-version = "1.10.0"
+version = "1.11.0"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"

--- a/plerkle_messenger/src/redis/redis_messenger.rs
+++ b/plerkle_messenger/src/redis/redis_messenger.rs
@@ -245,6 +245,13 @@ impl RedisMessenger {
         }
         Ok(())
     }
+
+    pub async fn stream_len(&mut self, stream_key: &'static str) -> Result<u64, MessengerError> {
+        Ok(self.connection.xlen(stream_key).await.map_err(|e| {
+            error!("Failed to read stream length: {}", e);
+            MessengerError::ConnectionError { msg: e.to_string() }
+        })?)
+    }
 }
 
 #[async_trait]

--- a/plerkle_snapshot/Cargo.toml
+++ b/plerkle_snapshot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Renamed from original "solana-snapshot-etl"
 name = "plerkle_snapshot"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 documentation = "https://docs.rs/solana-snapshot-etl"

--- a/plerkle_snapshot/src/bin/solana-snapshot-etl/main.rs
+++ b/plerkle_snapshot/src/bin/solana-snapshot-etl/main.rs
@@ -71,12 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    info!(
-        "Done! Accounts: {}",
-        dumper
-            .accounts_count
-            .load(std::sync::atomic::Ordering::Relaxed)
-    );
+    info!("Done! Accounts: {}", dumper.accounts_count);
 
     dumper.force_flush().await;
 


### PR DESCRIPTION
This pr:
1. adds a stream counter to the snapshot binary, which counts how many consecutive messages were sent
2. when the stream counter reaches some constant value (20M in our case), check accounts stream length to be below the desired value
3. if it's above the desired value, sleep in 1-second intervals until the stream length drops below the desired value
4. reset the stream counter and send another batch of accounts to the redis instance.