### PR TITLE
Update plerkle_serialization to have same version as plerkle_messenger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_messenger"
-version = "1.12.0"
+version = "2.0.0"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "plerkle_serialization"
-version = "1.10.0"
+version = "2.0.0"
 dependencies = [
  "bs58 0.4.0",
  "chrono",

--- a/plerkle/Cargo.toml
+++ b/plerkle/Cargo.toml
@@ -36,9 +36,9 @@ tracing-subscriber = { version = "0.3.16", features = [
   "ansi",
 ] }
 hex = "0.4.3"
-plerkle_messenger = { path = "../plerkle_messenger", version = "1.6.0" }
+plerkle_messenger = { path = "../plerkle_messenger", version = "2.0.0" }
 flatbuffers = "23.1.21"
-plerkle_serialization = { path = "../plerkle_serialization", version = "1.6.0" }
+plerkle_serialization = { path = "../plerkle_serialization", version = "2.0.0" }
 tokio = { version = "1.23.0", features = ["full"] }
 figment = { version = "0.10.6", features = ["env", "test"] }
 dashmap = {version = "5.4.0"}

--- a/plerkle_messenger/Cargo.toml
+++ b/plerkle_messenger/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_messenger"
 description = "Metaplex Messenger trait for Geyser plugin producer/consumer patterns."
-version = "1.12.0"
+version = "2.0.0"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"

--- a/plerkle_serialization/Cargo.toml
+++ b/plerkle_serialization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plerkle_serialization"
 description = "Metaplex Flatbuffers Plerkle Serialization for Geyser plugin producer/consumer patterns."
-version = "1.10.0"
+version = "2.0.0"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
 repository = "https://github.com/metaplex-foundation/digital-asset-validator-plugin"
 license = "AGPL-3.0"


### PR DESCRIPTION
Doing this because the CI publishes them together and makes a docker image that calls out a single version.