### PR TITLE
Add multi-arch Plerkle plugin image

### DIFF
--- a/.github/workflows/publish-plerkle-plugin.yml
+++ b/.github/workflows/publish-plerkle-plugin.yml
@@ -1,0 +1,81 @@
+name: Publish Plerkle plugin image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example v3.0.1"
+        required: true
+        type: string
+
+env:
+  PLERKLE_PLUGIN_IMAGE_NAME: plerkle-plugin
+  RUST_VERSION: 1.89.0
+  SOLANA_VERSION_STABLE: v3.1.13
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          agave_version="${SOLANA_VERSION_STABLE#v}"
+          echo "ci_tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "CI_TAG=${tag}" >> "$GITHUB_ENV"
+          echo "PLERKLE_PLUGIN_TAG=${tag}-rust${RUST_VERSION}-agave${agave_version}" >> "$GITHUB_ENV"
+          echo "PLERKLE_PLUGIN_IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/${PLERKLE_PLUGIN_IMAGE_NAME}" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.ci_tag }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Plerkle plugin image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: PlerklePlugin.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            RUST_VERSION=${{ env.RUST_VERSION }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ env.PLERKLE_PLUGIN_TAG }}
+          tags: |
+            ${{ env.PLERKLE_PLUGIN_IMAGE }}:${{ env.PLERKLE_PLUGIN_TAG }}
+
+      - name: Verify multi-arch image
+        run: |
+          set -euo pipefail
+          image="${PLERKLE_PLUGIN_IMAGE}:${PLERKLE_PLUGIN_TAG}"
+          docker buildx imagetools inspect "$image" | tee /tmp/plerkle-plugin-image.txt
+          grep -q 'linux/amd64' /tmp/plerkle-plugin-image.txt
+          grep -q 'linux/arm64' /tmp/plerkle-plugin-image.txt
+          docker run --rm --platform linux/amd64 --entrypoint test "$image" -f /plugin/plugin.so
+          docker run --rm --platform linux/arm64 --entrypoint test "$image" -f /plugin/plugin.so

--- a/PlerklePlugin.Dockerfile
+++ b/PlerklePlugin.Dockerfile
@@ -1,0 +1,33 @@
+ARG RUST_VERSION=1.89.0
+
+FROM --platform=$TARGETPLATFORM rust:${RUST_VERSION}-bullseye AS builder
+
+RUN apt-get update \
+      && apt-get install -y --no-install-recommends \
+           build-essential \
+           ca-certificates \
+           cmake \
+           libelf-dev \
+           libsasl2-dev \
+           libssl-dev \
+           libudev-dev \
+           libzstd-dev \
+           pkg-config \
+           protobuf-compiler \
+      && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /rust
+COPY Cargo.toml Cargo.lock ./
+COPY plerkle ./plerkle
+COPY plerkle_messenger ./plerkle_messenger
+COPY plerkle_serialization ./plerkle_serialization
+
+RUN cargo build --release --locked -p plerkle
+
+FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+
+LABEL org.opencontainers.image.title="Plerkle Geyser Plugin"
+LABEL org.opencontainers.image.description="Plerkle Geyser plugin artifact for DAS e2e validator images"
+LABEL org.opencontainers.image.source="https://github.com/metaplex-foundation/digital-asset-validator-plugin"
+
+COPY --from=builder /rust/target/release/libplerkle.so /plugin/plugin.so


### PR DESCRIPTION
## Summary
- add a PlerklePlugin.Dockerfile that exports /plugin/plugin.so only
- add a GHCR publish workflow for ghcr.io/metaplex-foundation/plerkle-plugin:<tag>-rust1.89.0-agave3.1.13
- build and verify linux/amd64 and linux/arm64 manifests plus plugin artifact presence

## Validation
- git diff --check

## Rollout
After merge, run the new Publish Plerkle plugin image workflow for tag v3.0.1 before building the DAS Surfpool validator image.